### PR TITLE
swap red color for a11y reasons

### DIFF
--- a/src/scss/_timestamp.scss
+++ b/src/scss/_timestamp.scss
@@ -49,7 +49,7 @@
 		&.o-teaser__timestamp--new,
 		&.o-teaser__timestamp--updated,
 		&.o-teaser__timestamp--inprogress {
-			@include oColorsFor('fast-ft', 'text');
+			color: oColorsGetPaletteColor('red');
 		}
 
 		&.o-teaser__timestamp--comingsoon {


### PR DESCRIPTION
cc: @onishiweb 

The standard origami red should work.