### PR TITLE
Amend: separate prefix from tag in meta

### DIFF
--- a/demos/src/demo-hero.mustache
+++ b/demos/src/demo-hero.mustache
@@ -2,7 +2,9 @@
 
 	<div class="o-teaser o-teaser--hero {{#article-modifier}}o-teaser--{{article-modifier}}{{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 

--- a/demos/src/demo-large-modifiers.mustache
+++ b/demos/src/demo-large-modifiers.mustache
@@ -2,7 +2,10 @@
 
 	<div class="o-teaser {{#article-modifier}}o-teaser--{{article-modifier}}{{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<span>{{article-tag-prefix}} </span>
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 

--- a/demos/src/demo-large.mustache
+++ b/demos/src/demo-large.mustache
@@ -2,7 +2,9 @@
 
 	<div class="o-teaser o-teaser--large {{#article-modifier}}o-teaser--{{article-modifier}}{{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 

--- a/demos/src/demo-top-story.mustache
+++ b/demos/src/demo-top-story.mustache
@@ -2,7 +2,9 @@
 
 	<div class="o-teaser o-teaser--top-story {{#article-modifier}}o-teaser--{{article-modifier}}{{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -2,7 +2,9 @@
 
 	<div class="o-teaser o-teaser--small {{#article-modifier}}o-teaser--{{article-modifier}}{{/article-modifier}} " data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			{{#article-promoted-by}}
 				<span class="o-teaser__promoted-prefix">{{article-promoted-prefix}}</span>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -3,7 +3,9 @@
 	<div class="o-teaser o-teaser--small" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			{{#article-tag}}
-				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
 			{{/article-tag}}
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
@@ -31,7 +33,9 @@
 	<div class="o-teaser o-teaser--small o-teaser--stacked" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			{{#article-tag}}
-				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
 			{{/article-tag}}
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
@@ -60,7 +64,9 @@
 	<div class="o-teaser o-teaser--small o-teaser--opinion o-teaser--has-headshot" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			{{#article-tag}}
-				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
 			{{/article-tag}}
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
@@ -84,7 +90,9 @@
 
 	<div class="o-teaser o-teaser--large-portrait o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -108,7 +116,9 @@
 
 	<div class="o-teaser o-teaser--large-landscape o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -132,7 +142,9 @@
 
 	<div class="o-teaser o-teaser--large o-teaser--has-image o-teaser--opinion" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -156,7 +168,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -180,7 +194,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--highlight" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -204,7 +220,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--opinion" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -228,7 +246,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--centre" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -252,7 +272,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--hero-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 		</div>
@@ -281,7 +303,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--opinion o-teaser--stretched" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -306,7 +330,9 @@
 	<div class="o-teaser o-teaser--small o-teaser--paid-post" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			{{#article-tag}}
-				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
 			{{/article-tag}}
 
 			{{#article-promoted-by}}
@@ -340,7 +366,9 @@
 	<div class="o-teaser o-teaser--small o-teaser--promoted-content" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			{{#article-tag}}
-				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
 			{{/article-tag}}
 
 			{{#article-promoted-by}}
@@ -380,7 +408,9 @@
 
 	<div class="o-teaser o-teaser--hero o-teaser--has-image o-teaser--standalone" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -404,7 +434,9 @@
 
 	<div class="o-teaser o-teaser--top-story o-teaser--standalone o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -436,7 +468,9 @@
 
 	<div class="o-teaser o-teaser--top-story o-teaser--landscape o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -470,7 +504,9 @@
 <div class="demo-container demo-container--large demo-container--top-story demo-container--big-story">
 	<div class="o-teaser o-teaser--top-story o-teaser--big-story o-teaser--has-image" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
@@ -504,7 +540,9 @@
 <div class="demo-container demo-container--inverse">
 	<div class="o-teaser o-teaser--large o-teaser--inverse" data-o-component="o-teaser">
 		<div class="o-teaser__content">
-			<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			<div class="o-teaser__meta">
+				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+			</div>
 
 			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 

--- a/main.scss
+++ b/main.scss
@@ -144,6 +144,10 @@
 		@include oTeaserContent;
 	}
 
+	.o-teaser__meta {
+		@include oTeaserMeta;
+	}
+
 	.o-teaser__tag {
 		@include oTeaserTag;
 	}

--- a/origami.json
+++ b/origami.json
@@ -257,6 +257,7 @@
 				"data": {
 					"article-modifier": "large-portrait",
 					"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=280&source=o-teaser-demo",
+					"article-tag-prefix": "Review",
 					"article-tag": "World",
 					"article-timestamp": "2016-02-29T12:35:48Z",
 					"article-heading": "Japan sells negative yield 10-year bonds",
@@ -271,6 +272,7 @@
 				"data": {
 					"article-modifier": "large-landscape",
 					"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=280&source=o-teaser-demo",
+					"article-tag-prefix": "Special Report",
 					"article-tag": "World",
 					"article-timestamp": "2016-02-29T12:35:48Z",
 					"article-heading": "Japan sells negative yield 10-year bonds",

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -286,10 +286,14 @@
 	}
 }
 
-@mixin oTeaserTag {
+@mixin oTeaserMeta {
 	@include font-size(16, 18);
 	@include oColorsFor('o-teaser-tag', 'text');
 	margin: 0;
+}
+
+@mixin oTeaserTag {
+	@include oColorsFor('o-teaser-tag', 'text');
 	font-weight: oFontsWeight(semibold);
 	text-decoration: none;
 	border: 0;
@@ -298,10 +302,6 @@
 		color: oTeaserTextColor($percent: 50);
 	}
 
-	strong {
-		font-weight: normal;
-	}
-	
 	span {
 		display: inline-block;
 	}

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -293,7 +293,7 @@
 }
 
 @mixin oTeaserTag {
-	@include oColorsFor('o-teaser-tag', 'text');
+	color: inherit;
 	font-weight: oFontsWeight(semibold);
 	text-decoration: none;
 	border: 0;

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -4,7 +4,8 @@
 		color: oTeaserTextColor(#ffffff, oColorsGetPaletteColor('black'), 60);
 	}
 
-	.o-teaser__tag {
+	.o-teaser__tag,
+	.o-teaser__meta {
 		color: oColorsGetPaletteColor('white');
 	}
 
@@ -18,7 +19,7 @@
 	}
 
 	&.o-teaser--hero {
-		.o-teaser__tag:after {
+		.o-teaser__meta:after {
 			border-bottom-color: oColorsGetPaletteColor('white');
 		}
 	}
@@ -40,7 +41,8 @@
 }
 
 @mixin oTeaserOpinion {
-	.o-teaser__tag {
+	.o-teaser__tag,
+	.o-teaser__meta {
 		color: $_o-teaser-color-opinion-tag;
 	}
 }
@@ -75,8 +77,13 @@
 	}
 
 	.o-teaser__standfirst,
-	.o-teaser__timestamp {
+	.o-teaser__timestamp,
+	.o-teaser__timestamp-prefix:before {
 		color: oTeaserTextColor(#ffffff, oColorsGetPaletteColor('claret-1'), 80);
+	}
+
+	.o-teaser__timestamp-prefix:before {
+		background-color: oTeaserTextColor(#ffffff, oColorsGetPaletteColor('claret-1'), 80);
 	}
 
 	&.o-teaser--hero {
@@ -100,8 +107,13 @@
 	}
 
 	.o-teaser__standfirst,
-	.o-teaser__timestamp {
+	.o-teaser__timestamp,
+	.o-teaser__timestamp-prefix:before {
 		color: oTeaserTextColor(#ffffff, $_o-teaser-color-hero-opinion-background, 80);
+	}
+
+	.o-teaser__timestamp-prefix:before {
+		background-color: oTeaserTextColor(#ffffff, $_o-teaser-color-hero-opinion-background, 80);
 	}
 
 	&.o-teaser--hero {
@@ -145,7 +157,7 @@
 		background-color: $_o-teaser-color-hero-background;
 	}
 
-	.o-teaser__tag:after {
+	.o-teaser__meta:after {
 		content: '';
 		display: block;
 		width: 60px;
@@ -200,12 +212,13 @@
 
 	.o-teaser__heading,
 	.o-teaser__tag,
+	.o-teaser__meta,
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {
 		color: oColorsGetPaletteColor('white');
 	}
 
-	.o-teaser__tag:after {
+	.o-teaser__meta:after {
 		border-bottom-color: oColorsGetPaletteColor('white');
 	}
 }
@@ -215,7 +228,7 @@
 		text-align: center;
 	}
 
-	.o-teaser__tag:after {
+	.o-teaser__meta:after {
 		margin-left: auto;
 		margin-right: auto;
 	}
@@ -350,6 +363,10 @@
 @mixin oTeaserPaidPost {
 	@include oColorsFor('o-teaser-theme-paid-post');
 	padding: 10px;
+
+	.o-teaser__meta {
+		color: #333333;
+	}
 
 	.o-teaser__promoted-prefix {
 		background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAC0AAAAtCAYAAAA6GuKaAAAAAXNSR0IArs4c6QAABdJJREFUWAntWGloXFUU/iaTfZI022TfJnts05RkUrtkim0imAYUoUJLQaogYhGqVlH8Z0u1oggaNSgUwahEEAQpLrU1Uk3SFNukW9JszTppmmQyk8k2ySzx3Ju8x2Ty5iUdJ0JgDrx5991z7r3f++6555w3Ct23ZxexycRvk+HlcH2g/69d8zHtY1qGAZ97yJDjVZWPaa/SKTOZj2kZcryq8jHtVTplJvMxLUOOV1Wbkml/KQqClf6oKatYoTIvLKDNNI7vezphWrCs0D2Zno2nM7LxYG4Wb129vELHHk4WlmBbtBqftrXg2tgDrhf6+MPiIsYtFvTPmPFjXxf0M9O8292PJNN+CgWywrdAQ1efeZJfwUoljmYVoGZvOVQBgSvmO6TJ4fZ74hKRFxm9QsceEkPDuD7MP0DUCX1zNhv0szMIDwjAIU0uah+rRGVKhmgn1ZBkWjC0Oxx4p6VJeET1ngMoIsZKYuJweWSI92+NikFGWAQu6QdQnpyGqpRMdJgmxDFrNb7rbsffD/TcrIDm+mT3AbxCO3PdMEY7NyM5XJJpSUvqjA4K5iqLwyaaHEzN5O1znbfRN23mwAP9Hmpaca52o4Fevh8h5J6l6nix37Uhy7SSFme+pyB3KY6JR4oqDNNWK+4al5gMIpcpT0pFj9mEoZkp1A8P4LncbdiXmIqLtLgnop9d8uc02j13Igua8fUUHTJBpgjw2RvNMFsXeNf+xDSEkp+a6JCygyj4elWqxmPQuVui+NyTC/PCsqvusqDtdKpPt17hg4x0urvMRs60MMvB1AzeLImNA7sEKY6NR0JoKEZmZ4Wudd39aWdLYxO47QC5mjuRBe0g0H/QAZOSZHKVIjqQw3TyLwz1iSYseuymKFKZosFXnXfE/rUaLMy+mL+dds6fh87msRG3Q2RBux1FCgZKQffzAz34hiKAICmq8CXQ5CLrAf1GkRYn7MVQh4SCueM8RayPbl3Dgt0uTLnq7hFoBvaJZde4RIfPWdiB7Jg0Io98s4QigJBMnG2c21GBwWD/y92nHeucnMC5jtvol3ENNlbh+y/PmcINbEu6R6JKhXe1OnHZebsNrZShmkfvo8UwKvbnRkbhWM5WZEdEgqX+Hkr5tV1tuG0cF2120aGsSErHjlg1bI5FtJsMqKUzYLU7cEq7R7RzbcxQeH258ZJrN3+WBB2oUPJagaVwFpsDFH7ICI/Ae6U6fN5+Az/1d0OXkIy3dzyKunsdqOvpAIs0RTFqvL9zH6rvtODXoV6wtHxGW4ZqKpTq7t1FoJ8S6TRPDr3kXyN6fNl+UwT10iNF6J404fflpGRbdIg614YkaMGodXwUhvmliq6B6gMhMvxGgF4r1HJwPw/2Cuac4cHpKbxZtBMNo3pYqBhi2bRhZBhjlqWY3UZMC9I0Oiw0cTS7AINU5Tn3iUqXBosy6xIlLa6lpDFMaTYzPBJRVIdckEjVrJBSUngpoHjdOzWJLookX+geRxXVKAHEtDdElulnyV/n7FaoKFXrElLAEsAPvZ0ojFLDYJkjH5XeQlZXs125ihG8euVPHKetf327Fi/kF/IYLFSInr6ALNMZVE9nEauxwaGc1WOXf+Hx1GSdR0RgkNs1mc60XDvM2qz48OY/OFJ/HszFTmv34nBmvtux61HIMn3qeqPo086TDVLwD6I6IS0sHAPkw84SQ27DriGXflaHfEDgWcF/ME3DD6bzuIdpyzLtbiKWvVonxnCEvmRc5XBWPhVWJspuRoRQHeEqPRQhWInLQqSn4hFotlgNhb6KpDSwUBUfooKaXOh5qqVZifpZWyvHszs+CWdKy3joY7V3zpZIHM0pwA3DOA+RnoJeTcU6Z2JfGccbL+LkNi2e0eRx5licPdFUjzukY3KLwOnik/Hxrv10iJXc1Zhff00J6L+IV2oPFlXYbrOPVHfCPtUmlmO+O5v19nvMtPMCFkrza4m3ALN1PPbptUBupN4HeiPZdZ77X4O+DYUynEAPAAAAAElFTkSuQmCC);

--- a/src/scss/_themes.scss
+++ b/src/scss/_themes.scss
@@ -4,7 +4,6 @@
 		color: oTeaserTextColor(#ffffff, oColorsGetPaletteColor('black'), 60);
 	}
 
-	.o-teaser__tag,
 	.o-teaser__meta {
 		color: oColorsGetPaletteColor('white');
 	}
@@ -41,7 +40,6 @@
 }
 
 @mixin oTeaserOpinion {
-	.o-teaser__tag,
 	.o-teaser__meta {
 		color: $_o-teaser-color-opinion-tag;
 	}
@@ -211,7 +209,6 @@
 	}
 
 	.o-teaser__heading,
-	.o-teaser__tag,
 	.o-teaser__meta,
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {


### PR DESCRIPTION
cc: @onishiweb 

Have separated out the prefix from the tag (and managed to do away with the `<strong>` hack.

(Here's the associated n-teaser PR https://github.com/Financial-Times/n-teaser/pull/48)

Updated the demos for the required structure and put prefixes in a couple.

Also tidied a couple of timestamp issues where the red dot appears on the burgundy / dark blue to make them the same colour as the timestamp.