### PR TITLE
Add: image position right option for small teasers

### DIFF
--- a/main.scss
+++ b/main.scss
@@ -35,6 +35,10 @@
 		&.o-teaser--stacked {
 			@include oTeaserSmallStacked;
 		}
+
+		&.o-teaser--image-position-right {
+			@include oTeaserSmallImagePositionRight;
+		}
 	}
 
 	// Large teasers

--- a/origami.json
+++ b/origami.json
@@ -51,6 +51,19 @@
 				}
 			},
 			{
+				"name": "small-image-right",
+				"description": "Small teaser with image positioned to the right",
+				"template": "demos/src/demo.mustache",
+				"data": {
+					"article-modifier": "image-position-right",
+					"article-tag": "World",
+					"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
+					"article-timestamp": "2016-02-29T12:35:48Z",
+					"article-heading": "Japan sells negative yield 10-year bonds",
+					"article-standfirst": "Bondholders pay government for the privilege of lending it money"
+				}
+			},
+			{
 				"name": "small-image-stacked",
 				"description": "Small teaser with stacked image",
 				"template": "demos/src/demo.mustache",

--- a/src/scss/_small.scss
+++ b/src/scss/_small.scss
@@ -43,3 +43,16 @@
 		}
 	}
 }
+
+@mixin oTeaserSmallImagePositionRight {
+
+	&.o-teaser--has-image {
+
+		.o-teaser__image-container {
+			order: 2;
+			padding-left: oGridGutter(M);
+			padding-right: inherit;
+		}
+
+	}
+}


### PR DESCRIPTION
cc: @onishiweb 

Enables choice to position image in small teasers to the right of the content.