### PR TITLE
Amend: reduce min height of image overlay

### DIFF
--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -96,7 +96,7 @@
 			left: 0;
 			z-index: 1;
 			width: 100%;
-			min-height: 60%;
+			min-height: 30%;
 			background-color: transparent;
 			background-image: linear-gradient(to bottom, rgba(oColorsGetPaletteColor('black'), 0.75), transparent);
 			pointer-events: none;


### PR DESCRIPTION
@onishiweb 

We've been getting complaints from Life & Arts that the new overlay is making the images too dark.  Notice that o-teaser applies a 60% min height to the linear gradient. Reducing it to 30% improves the image viewability a lot.