### PR TITLE
add indicator for content which is defintely not syndicatable

### DIFF
--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -16,8 +16,8 @@
 
 			<h2 class="o-teaser__heading">
 				{{#article-canBeSyndicated}}
-					<a href="#" class="o-teaser__syndication-indicator"><span>Syndication allowed</span></a>
-				{{/article-canBeSyndicated}}
+					<a href="#" class="o-teaser__syndication-indicator o-teaser__syndication-indicator--{{article-canBeSyndicated}}"><span>Syndication allowed</span></a>
+                {{/article-canBeSyndicated}}
 				<a href="#">{{article-heading}}</a>
 			</h2>
 

--- a/origami.json
+++ b/origami.json
@@ -46,7 +46,18 @@
 					"article-tag": "World",
 					"article-heading": "Japan sells negative yield 10-year bonds",
 					"article-timestamp": "2016-02-29T12:35:48Z",
-					"article-canBeSyndicated": true
+					"article-canBeSyndicated": "yes"
+				}
+			},
+			{
+				"name": "small-not-syndicatable",
+				"description": "Small teaser",
+				"template": "demos/src/demo.mustache",
+				"data": {
+					"article-tag": "World",
+					"article-heading": "Japan sells negative yield 10-year bonds",
+					"article-timestamp": "2016-02-29T12:35:48Z",
+					"article-canBeSyndicated": "no"
 				}
 			},
 			{

--- a/src/scss/elements/_syndication.scss
+++ b/src/scss/elements/_syndication.scss
@@ -1,8 +1,6 @@
 
 @mixin oTeaserSyndicationIndicator {
 	.o-teaser__syndication-indicator {
-		@include oIconsGetIcon('tick', oColorsGetPaletteColor('white'), 20);
-		background-color: oColorsGetPaletteColor('green');
 		border-radius: 50%;
 
 		span {
@@ -14,6 +12,16 @@
 			width: 1px;
 			overflow: hidden;
 		}
+	}
+
+	.o-teaser__syndication-indicator--yes {
+		@include oIconsGetIcon('tick', oColorsGetPaletteColor('white'), 20);
+		background-color: oColorsGetPaletteColor('green');
+	}
+
+	.o-teaser__syndication-indicator--no {
+		@include oIconsGetIcon('minus', oColorsGetPaletteColor('white'), 20);
+		background-color: oColorsGetPaletteColor('red');
 	}
 }
 


### PR DESCRIPTION
So it turns out there should be 2 indicators - a green tick when an article IS syndicatable and a red minus for when an article is definitely NOT syndicatable (mostly fastFt and letters).

This PR adds some additional classes to differentiate.