### PR TITLE
Improve: Contrast for focus state of inverse teaser tag

### DIFF
--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -40,7 +40,8 @@
 /// Hero opinion theme - blue background white based text
 @mixin oTeaserHeroOpinion {
 	.o-teaser__heading:hover,
-	.o-teaser__tag:hover {
+	.o-teaser__tag:hover,
+	.o-teaser__tag:focus {
 		color: oTeaserTextColor(#ffffff, $_o-teaser-color-hero-opinion-background, 73);
 	}
 


### PR DESCRIPTION
Fixes: https://github.com/Financial-Times/next-a11y/issues/68

#### From:
![from](https://cloud.githubusercontent.com/assets/10484515/22656601/c88c67d8-ec8b-11e6-8284-baa21553599a.png)

#### To:
![to](https://cloud.githubusercontent.com/assets/10484515/22656607/ce5e6bac-ec8b-11e6-9418-bb7c7687cdde.png)