### PR TITLE
Add: outside-page icon to promoted content headline

### DIFF
--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -1,7 +1,15 @@
 /// Promoted content theme
 @mixin oTeaserPromotedContent {
 	@include oColorsFor('o-teaser-theme-promoted-content');
-	padding: 10px;
+	padding: 10px 32px 10px 10px;
+
+	.o-teaser__content:after {
+		@include oIconsGetIcon('outside-page', oTeaserTextColor($percent: 80), 32);
+		content: '';
+		position: absolute;
+		top: 3px;
+		right: 0;
+	}
 
 	.o-teaser__meta {
 		font-weight: oFontsWeight(semibold);
@@ -12,10 +20,6 @@
 		@include oColorsFor('o-teaser-promoted-prefix', 'text');
 	}
 
-	.o-teaser__heading a:after {
-			@include oIconsGetIcon('outside-page', oTeaserTextColor($percent: 80), 20);
-			content: '';
-	}
 }
 
 /// Paid post theme

--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -11,6 +11,11 @@
 	.o-teaser__promoted-prefix {
 		@include oColorsFor('o-teaser-promoted-prefix', 'text');
 	}
+
+	.o-teaser__heading a:after {
+			@include oIconsGetIcon('outside-page', oTeaserTextColor($percent: 80), 20);
+			content: '';
+	}
 }
 
 /// Paid post theme


### PR DESCRIPTION
Promoted content teasers will open their target in a new tab / window.

Should only be released after change to n-teaser that opens the link in an outside page - PR (https://github.com/Financial-Times/n-teaser/pull/89)

Puts an icon on promoted content flavour teasers absolutely positioned to the top right hand corner.

![screen shot 2017-03-23 at 13 39 19](https://cloud.githubusercontent.com/assets/8938227/24250432/c98dc9f4-0fce-11e7-8653-7d16b8e0933f.png)



