### PR TITLE
fix(placeholder): respect loaded img aspect ratio

### DIFF
--- a/src/scss/elements/_images.scss
+++ b/src/scss/elements/_images.scss
@@ -14,9 +14,7 @@
 	z-index: 1;
 
 	.o-teaser__image {
-		position: absolute;
-		top: 0;
-		left: 0;
+		float: left; 
 	}
 }
 


### PR DESCRIPTION
Fixes https://jira.ft.com/browse/NFT-849 (lazy-load image placeholder not respecting loaded image aspect ratio + content overlap)

