### PR TITLE
restore red and amber styles for old syndication

### DIFF
--- a/src/scss/elements/_syndication.scss
+++ b/src/scss/elements/_syndication.scss
@@ -27,11 +27,13 @@
 		background-color: oColorsGetPaletteColor('jade');
 	}
 
+	.o-teaser__syndication-indicator--no,
 	.syndi.o-teaser__syndication-indicator--no {
 		@include oIconsGetIcon('minus', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
 		background-color: oColorsGetPaletteColor('crimson');
 	}
 
+	.o-teaser__syndication-indicator--verify,
 	.syndi.o-teaser__syndication-indicator--verify {
 		@include oIconsGetIcon('tick', oColorsGetPaletteColor('white'), 20, $iconset-version: 1);
 		background-color: oColorsGetPaletteColor('mandarin');


### PR DESCRIPTION
The icons that aren't showing up as in https://www.ft.com/content/a94326ac-5dbd-11e7-9bc8-8055f264aa8b are meant to be red, but they have no styling. 

Does this interfere with the work you're currently doing @constantology?