### PR TITLE
Fix for issue on next-front-page. Replace flex-basis 100% with auto

### DIFF
--- a/demos/src/demo.scss
+++ b/demos/src/demo.scss
@@ -26,7 +26,6 @@ body {
 
 	&--stretched {
 		display: flex;
-		height: 400px;
 	}
 
 	&--big-story {

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -34,7 +34,7 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-		flex-basis: 100%;
+		flex-basis: auto;
 	}
 
 	.o-teaser__heading {


### PR DESCRIPTION
This fixes an issue raised on 05/07/17 with content of o-teaser with `.o-teaser--stretched .o-teaser__content` was overflowing in safari 
See https://jira.ft.com/browse/NFT-876 for details