### PR TITLE
Fix package icon and stretchability

### DIFF
--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -2,6 +2,7 @@
 	@include oTeaserInverse;
 	@include oTeaserPackageList;
 	width: 100%;
+	flex-flow: column nowrap;
 
 	.o-teaser__image-placeholder {
 		z-index: -1;
@@ -129,7 +130,7 @@
 			}
 
 			&:after {
-				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-teaser-package-basic, text), 30);
+				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-teaser-package-basic, text), 30, $iconset-version: 1);
 				content: '';
 				position: absolute;
 				bottom: 18px;
@@ -156,7 +157,7 @@
 			}
 
 			&:after {
-				@include oIconsGetIcon('arrow-right', oColorsGetPaletteColor('white'), 30);
+				@include oIconsGetIcon('arrow-right', oColorsGetPaletteColor('white'), 30, $iconset-version: 1);
 			}
 		}
 	}
@@ -180,7 +181,7 @@
 			}
 
 			&:after {
-				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-teaser-theme-hero-extra-highlight, text), 30); //lemon
+				@include oIconsGetIcon('arrow-right', oColorsGetColorFor(o-teaser-theme-hero-extra-highlight, text), 30, $iconset-version: 1); //lemon
 			}
 		}
 	}


### PR DESCRIPTION
* Package teasers, when stretched, were stretching in a row instead of a column. Add a `flex-flow` to package teasers to match what is on hero teasers.
* Force the package icon to v1 so it stays the correct size.

Before:
![screen shot 2017-07-26 at 14 57 18](https://user-images.githubusercontent.com/1978880/28625039-fa9ceefc-7212-11e7-8c3b-26161b90ade7.png)

After:
![screen shot 2017-07-26 at 14 55 36](https://user-images.githubusercontent.com/1978880/28625044-fff46538-7212-11e7-848b-6650204bba33.png)
