### PR TITLE
Fix for IE11 flexbox wrap

### DIFF
--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -20,6 +20,11 @@
 		@include oGridRespondTo($until: M) { // Mobile screens only
 			display: none;
 		}
+
+		//hack because IE11 and flexbox aren't friends
+		.top-stories__freeform-twocolumns & {
+			max-width: 30%;
+		}
 	}
 }
 

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -14,16 +14,12 @@
 	.o-teaser__image-container {
 		flex: 0 0 30%;
 		width: 30%;
+		max-width: 30%;
 		padding-top: 4px; // to line up with tag cap-height
 		padding-right: oGridGutter(M);
 
 		@include oGridRespondTo($until: M) { // Mobile screens only
 			display: none;
-		}
-
-		//hack because IE11 and flexbox aren't friends
-		.top-stories__freeform-twocolumns & {
-			max-width: 30%;
 		}
 	}
 }
@@ -40,6 +36,7 @@
 
 	.o-teaser__image-container {
 		margin-bottom: 16px;
+		max-width: 100%;
 
 		@include oGridRespondTo(M) {
 			flex: 1 0 100%;


### PR DESCRIPTION
Because of this issue: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/106816/ content isn't wrapping around images in `o-teaser--small` in the `top-stories__freeform-twocolumns` section of the homepage for IE11.