### PR TITLE
Revert "Fix for IE11 flexbox wrap"

### DIFF
--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -14,7 +14,6 @@
 	.o-teaser__image-container {
 		flex: 0 0 30%;
 		width: 30%;
-		max-width: 30%;
 		padding-top: 4px; // to line up with tag cap-height
 		padding-right: oGridGutter(M);
 
@@ -36,7 +35,6 @@
 
 	.o-teaser__image-container {
 		margin-bottom: 16px;
-		max-width: 100%;
 
 		@include oGridRespondTo(M) {
 			flex: 1 0 100%;


### PR DESCRIPTION
Reverts Financial-Times/o-teaser#68

The PR this reverts has introduced a bug in the "Recommend" section on stream pages. 
![screenshot 2017-08-16 17 39 48](https://user-images.githubusercontent.com/11544418/29374657-157403f8-82aa-11e7-876b-078c0c52dbbd.png)

Which should look like 
![screenshot 2017-08-16 17 40 00](https://user-images.githubusercontent.com/11544418/29374667-1ecceabe-82aa-11e7-9222-47f6f1e17c5a.png)

