### PR TITLE
fixes teaser text overlap

### DIFF
--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -6,8 +6,8 @@
 	border-bottom: 1px solid oColorsGetColorFor('o-teaser', border);
 
 	.o-teaser__content {
-		// don't use short hand as IE will apply 0 height as flex basis 😐
-		flex-grow: 1;
+		// IE needs a unit to apply flex-basis correctly 😐
+		flex: 1 0 0%;
 		order: 2;
 	}
 
@@ -28,6 +28,10 @@
 /// image will appear 100% width at the top of the teaser
 @mixin oTeaserSmallStacked {
 	flex-direction: column;
+	
+	.o-teaser__content {
+		flex-basis: auto; // must override original .o-teaser__content flex-basis, and is influenced by flex-direction
+	}
 
 	@include oGridRespondTo(M) {
 		border-bottom: 0;

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -2,7 +2,6 @@
 @mixin oTeaserSmall {
 	@include oTypographyPadding($bottom: 4);
 	display: flex;
-	justify-content: space-between;
 	border-bottom: 1px solid oColorsGetColorFor('o-teaser', border);
 
 	.o-teaser__content {
@@ -30,12 +29,12 @@
 	flex-direction: column;
 	
 	.o-teaser__content {
-		flex-basis: auto; // must override original .o-teaser__content flex-basis, and is influenced by flex-direction
+		flex-basis: auto; // must override original .o-teaser__content flex-basis
 	}
 
 	@include oGridRespondTo(M) {
 		border-bottom: 0;
-		padding-bottom: 0px;
+		padding-bottom: 0;
 	}
 
 	.o-teaser__image-container {
@@ -43,11 +42,8 @@
 		width: 100%;
 		// <https://connect.microsoft.com/IE/feedbackdetail/view/891815>
 		min-height: 1px;
-
-		@include oGridRespondTo(M) {
-			padding-top: 0;
-			padding-right: 0;
-		}
+		padding-top: 0;
+		padding-right: 0;
 	}
 }
 


### PR DESCRIPTION
In relation to: https://jira.ft.com/browse/NFT-905

In IE10 exclusively, flexbox seems to create a little bug if `flex-basis` isn't defined, and the [short hand can be used as long a unit is declared](https://github.com/philipwalton/flexbugs#4-flex-shorthand-declarations-with-unitless-flex-basis-values-are-ignored). Because specificity, this needs overriding in the stacked version of teasers. 

Before:
![screen shot 2017-09-05 at 14 18 07](https://user-images.githubusercontent.com/16777943/30063024-1351d74e-9245-11e7-91ac-892e67a64dce.png)

After:
![screen shot 2017-09-05 at 14 18 59](https://user-images.githubusercontent.com/16777943/30063048-2b04e0f2-9245-11e7-9a57-c755bfd75511.png)
