### PR TITLE
live red background applies to small only

### DIFF
--- a/demos/src/demo-large.mustache
+++ b/demos/src/demo-large.mustache
@@ -17,7 +17,10 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
+			<div class="o-teaser__timestamp {{#is-live}}o-teaser__timestamp--inprogress{{/is-live}}">
+				{{#is-live}}<span class="o-teaser__timestamp-prefix">Live</span>{{/is-live}}
 				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+			</div>
 			{{/article-timestamp}}
 		</div>
 

--- a/demos/src/demo-large.mustache
+++ b/demos/src/demo-large.mustache
@@ -1,6 +1,6 @@
 <div class="demo-container demo-container--large {{#article-modifier}} demo-container--{{.}} {{/article-modifier}}">
 
-	<div class="o-teaser o-teaser--large {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
+	<div class="o-teaser o-teaser--large {{#is-live}}o-teaser--live{{/is-live}} {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
 				{{#article-tag-prefix}}<span class="o-teaser__tag-prefix">{{.}}</span>{{/article-tag-prefix}}

--- a/origami.json
+++ b/origami.json
@@ -287,6 +287,17 @@
 				}
 			},
 			{
+				"name": "large-live",
+				"description": "Large live teaser default theme",
+				"template": "demos/src/demo-large.mustache",
+				"data": {
+					"article-timestamp": "2016-02-29T12:35:48Z",
+					"article-heading": "Japan sells negative yield 10-year bonds",
+					"article-standfirst": "Bondholders pay government for the privilege of lending it money",
+					"is-live": true
+				}
+			},
+			{
 				"name": "large-image",
 				"description": "Large teaser default theme with image",
 				"template": "demos/src/demo-large.mustache",

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -10,7 +10,7 @@
         }
     }
 
-    .o-teaser--live {
+    .o-teaser--small.o-teaser--live {
         // create white text red background
         @include oTeaserInverse;
         background: oColorsGetPaletteColor('crimson');

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -24,7 +24,8 @@
         .o-teaser__timestamp--inprogress:before {
             background-color: white;
         }
-
+    }
+    .o-teaser--live {
         // move "LIVE" to the top without changing the HTML
         .o-teaser__content {
             display: flex;


### PR DESCRIPTION
Small teaser must have a red background but large teasers don't

This PR will allow to get this result in n-teaser:

![image](https://user-images.githubusercontent.com/7448436/30739543-ad105cbe-9f85-11e7-8aa4-f72fb7ebf16a.png)