### PR TITLE
Use v1 for outside-page as it is not in v0

### DIFF
--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -10,7 +10,7 @@
 	}
 
 	.o-teaser__content:after {
-		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('black-80'), 32);
+		@include oIconsGetIcon('outside-page', oColorsGetPaletteColor('black-80'), 32, $iconset-version: 1);
 		content: '';
 		position: absolute;
 		top: 3px;


### PR DESCRIPTION
I saw this specific icon in our splunk dashboard errors panel.
I noticed that it doesn't exist in V0 and the mixin is not forcing a specific iconset version. What this means is if o-icons V4 is being used then iconset V0 will be used and will return an error when requesting the icon whereas o-icons V5 will work as it uses iconset V1 by default.