### PR TITLE
Hover states on links rather than containing <div/>

### DIFF
--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -37,19 +37,15 @@
 	@include oTypographyMargin($top: 0, $bottom: 0);
 	font-weight: oFontsWeight(normal);
 
-	&:hover,
-	&:focus {
-		@include oColorsFor('o-teaser', text, 55);
-	}
-
 	a {
 		padding: 2px 0;
 		color: inherit;
 		text-decoration: none;
 		border: 0;
 
+		&:focus,
 		&:hover {
-			color: inherit;
+			@include oColorsFor('o-teaser', text, 55);
 		}
 	}
 }

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -103,6 +103,7 @@
 			pointer-events: none;
 		}
 
+		.o-teaser__heading,
 		.o-teaser__heading a,
 		.o-teaser__heading a:visited,
 		.o-teaser__meta,

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -38,7 +38,7 @@
 
 /// Hero opinion theme - blue background white based text
 @mixin oTeaserHeroOpinion {
-	.o-teaser__heading:hover,
+	.o-teaser__heading a:hover,
 	.o-teaser__heading:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
@@ -103,6 +103,7 @@
 		}
 
 		.o-teaser__heading,
+		.o-teaser__heading a,
 		.o-teaser__meta,
 		.o-teaser__standfirst,
 		.o-teaser__timestamp {
@@ -181,7 +182,7 @@
 
 // Hero Package theme — extra
 @mixin oTeaserHeroExtra {
-	.o-teaser__heading:hover,
+	.o-teaser__heading a:hover,
 	.o-teaser__heading:focus {
 		@include oColorsFor(o-teaser-theme-hero-extra-highlight, text);
 	}

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -39,7 +39,7 @@
 /// Hero opinion theme - blue background white based text
 @mixin oTeaserHeroOpinion {
 	.o-teaser__heading a:hover,
-	.o-teaser__heading:focus,
+	.o-teaser__heading a:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-hero-opinion', text, 73);
@@ -183,7 +183,7 @@
 // Hero Package theme — extra
 @mixin oTeaserHeroExtra {
 	.o-teaser__heading a:hover,
-	.o-teaser__heading:focus {
+	.o-teaser__heading a:focus {
 		@include oColorsFor(o-teaser-theme-hero-extra-highlight, text);
 	}
 

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -37,7 +37,7 @@
 		margin-top: -52px;
 		width: 100%;
 
-		&:hover,
+		a:hover,
 		&:focus {
 			@include oColorsFor('o-teaser', text, 55);
 		}
@@ -62,7 +62,7 @@
 	.o-teaser__heading {
 		color: oColorsGetPaletteColor('white');
 
-		&:hover,
+		a:hover,
 		&:focus {
 			@include oColorsFor(o-teaser-package-special-report, text, 73);
 		}
@@ -87,7 +87,7 @@
 	.o-teaser__heading {
 		color: oColorsGetPaletteColor('white');
 
-		&:hover,
+		a:hover,
 		&:focus {
 			@include oColorsFor('o-teaser-theme-hero-extra-highlight', text);
 		}

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -1,7 +1,7 @@
 /// Inverse theme styles - base all text content on white
 @mixin oTeaserInverse {
 	.o-teaser__heading a:hover,
-	.o-teaser__heading:focus,
+	.o-teaser__heading a:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-inverse', text, 60);
@@ -76,7 +76,7 @@
 /// Highlight theme - colours background claret and adjust text colours
 @mixin oTeaserHighlight {
 	.o-teaser__heading a:hover,
-	.o-teaser__heading:focus,
+	.o-teaser__heading a:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-hero-highlight', text, 73);

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -75,7 +75,7 @@
 
 /// Highlight theme - colours background claret and adjust text colours
 @mixin oTeaserHighlight {
-	.o-teaser__heading:hover,
+	.o-teaser__heading a:hover,
 	.o-teaser__heading:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -1,7 +1,7 @@
 /// Inverse theme styles - base all text content on white
 @mixin oTeaserInverse {
-	.o-teaser__heading:hover,
-	.o-teaser__heading:focus,
+	.o-teaser__heading a:hover,
+	.o-teaser__heading a:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-inverse', text, 60);

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -1,7 +1,7 @@
 /// Inverse theme styles - base all text content on white
 @mixin oTeaserInverse {
 	.o-teaser__heading a:hover,
-	.o-teaser__heading a:focus,
+	.o-teaser__heading:focus,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-inverse', text, 60);


### PR DESCRIPTION
To more accurately let the user know when they are near something interactive. The link text colour will now also change on focus.

This change avoids this:

![arhr5e7ayp](https://user-images.githubusercontent.com/295469/35228750-65a3cd02-ff89-11e7-899f-819a9117f80e.gif)
