### PR TITLE
Fix for link visited colour

### DIFF
--- a/demos/src/demo-hero.mustache
+++ b/demos/src/demo-hero.mustache
@@ -10,7 +10,7 @@
 				{{/article-duration}}
 			</div>
 
-			<h2 class="o-teaser__heading o-teaser__heading--visited"><a href="#">{{article-heading}}</a></h2>
+			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
 
 			{{#article-standfirst}}
 				<p class="o-teaser__standfirst">{{article-standfirst}}</p>

--- a/demos/src/demo-hero.mustache
+++ b/demos/src/demo-hero.mustache
@@ -10,7 +10,7 @@
 				{{/article-duration}}
 			</div>
 
-			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
+			<h2 class="o-teaser__heading o-teaser__heading--visited"><a href="#">{{article-heading}}</a></h2>
 
 			{{#article-standfirst}}
 				<p class="o-teaser__standfirst">{{article-standfirst}}</p>

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -45,6 +45,12 @@
 		@include oColorsFor('o-teaser-hero-opinion', text, 73);
 	}
 
+	.o-teaser__heading {
+		a:visited {
+			@include oColorsFor('o-teaser-hero-opinion', text, 73);
+		}
+	}
+
 	.o-teaser__standfirst,
 	.o-teaser__timestamp,
 	.o-teaser__timestamp-prefix:before {
@@ -108,6 +114,12 @@
 		.o-teaser__timestamp {
 			color: oColorsGetPaletteColor('white');
 			pointer-events: auto;
+		}
+
+		.o-teaser__heading {
+			a:visited {
+				color: oColorsGetPaletteColor('white');
+			}
 		}
 
 		.o-teaser__meta:after {
@@ -201,6 +213,9 @@
 
 	.o-teaser__heading {
 		color: oColorsGetPaletteColor('white');
+		a:visited {
+			@include oColorsFor(o-teaser-theme-hero-extra, text, 50);
+		}
 	}
 
 	.o-teaser__standfirst {

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -40,15 +40,10 @@
 @mixin oTeaserHeroOpinion {
 	.o-teaser__heading:hover,
 	.o-teaser__heading:focus,
+	.o-teaser__heading a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-hero-opinion', text, 73);
-	}
-
-	.o-teaser__heading {
-		a:visited {
-			@include oColorsFor('o-teaser-hero-opinion', text, 73);
-		}
 	}
 
 	.o-teaser__standfirst,
@@ -109,17 +104,12 @@
 		}
 
 		.o-teaser__heading,
+		.o-teaser__heading a:visited,
 		.o-teaser__meta,
 		.o-teaser__standfirst,
 		.o-teaser__timestamp {
 			color: oColorsGetPaletteColor('white');
 			pointer-events: auto;
-		}
-
-		.o-teaser__heading {
-			a:visited {
-				color: oColorsGetPaletteColor('white');
-			}
 		}
 
 		.o-teaser__meta:after {

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -63,10 +63,8 @@
 		color: oColorsGetPaletteColor('white');
 
 		&:hover,
+		a:visited,
 		&:focus {
-			@include oColorsFor(o-teaser-package-special-report, text, 73);
-		}
-		a:visited {
 			@include oColorsFor(o-teaser-package-special-report, text, 73);
 		}
 	}

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -66,6 +66,9 @@
 		&:focus {
 			@include oColorsFor(o-teaser-package-special-report, text, 73);
 		}
+		a:visited {
+			@include oColorsFor(o-teaser-package-special-report, text, 73);
+		}
 	}
 }
 

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -2,15 +2,10 @@
 @mixin oTeaserInverse {
 	.o-teaser__heading:hover,
 	.o-teaser__heading:focus,
+	.o-teaser__heading a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-inverse', text, 60);
-	}
-
-	.o-teaser__heading {
-		a:visited {
-			@include oColorsFor('o-teaser-inverse', text, 60);
-		}
 	}
 
 	.o-teaser__meta,
@@ -83,15 +78,10 @@
 @mixin oTeaserHighlight {
 	.o-teaser__heading:hover,
 	.o-teaser__heading:focus,
+	.o-teaser__heading a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-hero-highlight', text, 73);
-	}
-
-	.o-teaser__heading {
-		a:visited {
-			@include oColorsFor('o-teaser-hero-highlight', text, 73);
-		}
 	}
 
 	.o-teaser__standfirst,

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -7,6 +7,12 @@
 		@include oColorsFor('o-teaser-inverse', text, 60);
 	}
 
+	.o-teaser__heading {
+		a:visited {
+			@include oColorsFor('o-teaser-inverse', text, 60);
+		}
+	}
+
 	.o-teaser__meta,
 	.o-teaser__duration,
 	.o-teaser__heading {
@@ -80,6 +86,12 @@
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
 		@include oColorsFor('o-teaser-hero-highlight', text, 73);
+	}
+
+	.o-teaser__heading {
+		a:visited {
+			@include oColorsFor('o-teaser-hero-highlight', text, 73);
+		}
 	}
 
 	.o-teaser__standfirst,


### PR DESCRIPTION
This PR is a follow-up to yesterday's one (https://github.com/Financial-Times/o-teaser/pull/83) and it's basically a fix for a few edge cases (teasers with coloured background). 