### PR TITLE
White timestamp on extra teasers

### DIFF
--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -93,6 +93,10 @@
 			@include oColorsFor('o-teaser-theme-hero-extra-highlight', text);
 		}
 	}
+	
+	.o-teaser__timestamp {
+		color: oColorsGetPaletteColor('white');
+	}
 }
 
 @mixin oTeaserPackageList {


### PR DESCRIPTION
I'm not sure why this started failing our pa11y builds on articles - especially cause there's no text (unless it checks before JS runs?).

Anyway, this should fix it.