### PR TITLE
Implement experimental visited teaser heading style.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -55,13 +55,6 @@
 		@include oTeaserHeading;
 	}
 
-	.o-teaser__heading--visited {
-		@include oColorsFor('o-teaser', text, 100);
-		a:visited {
-			@include oColorsFor('o-teaser', text, 60);
-		}
-	}
-
 	.o-teaser__standfirst {
 		@include oTeaserStandfirst;
 	}

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -47,6 +47,10 @@
 		&:hover {
 			@include oColorsFor('o-teaser', text, 55);
 		}
+
+		&:visited {
+			@include oColorsFor('o-teaser', text, 60);
+		}
 	}
 }
 

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -33,7 +33,7 @@
 /// Including link and hover styling.
 @mixin oTeaserHeading {
 	@include oTypographyDisplay(2);
-	@include oColorsFor('o-teaser', text, 80);
+	@include oColorsFor('o-teaser', text, 100);
 	@include oTypographyMargin($top: 0, $bottom: 0);
 	font-weight: oFontsWeight(normal);
 

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -31,7 +31,7 @@
 
 	.o-teaser__heading {
 		@include oTypographySans(4);
-		@include oColorsFor('o-teaser', text, 80);
+		@include oColorsFor('o-teaser', text, 100);
 		background: inherit;
 		padding: 20px;
 		margin-top: -52px;
@@ -93,7 +93,7 @@
 			@include oColorsFor('o-teaser-theme-hero-extra-highlight', text);
 		}
 	}
-	
+
 	.o-teaser__timestamp {
 		color: oColorsGetPaletteColor('white');
 	}


### PR DESCRIPTION
`o-teaser__heading--visited a:visited` was added to support an experiemnt. As the experiment was a success this class can be removed in favour of `.o-teaser__heading a:visited`.

Details on issue: https://github.com/Financial-Times/o-teaser/issues/85

Before merge need to confirm flag `visitedStoriesOnTeaser` is true for all teasers.
https://github.com/Financial-Times/n-teaser/blob/13a956766f3ebd9f4446331ec8836da2d4c42f3c/src/presenters/teaser-presenter.js#L432