### PR TITLE
Remove the visited state for live teasers

### DIFF
--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -20,6 +20,10 @@
                 color: white;
             }
         }
+
+        .o-teaser__heading a:visited {
+            color: oColorsGetPaletteColor('white-80');
+        }
         .o-teaser__timestamp-prefix:before,
         .o-teaser__timestamp--inprogress:before {
             background-color: white;


### PR DESCRIPTION
Currently liveblog teasers have a gross visited state:
<img width="289" alt="screen shot 2018-06-14 at 14 54 37" src="https://user-images.githubusercontent.com/1978880/41416498-eb730424-6fe2-11e8-92f5-6f727916d7bf.png">

This PR makes it white.