### PR TITLE
Adds pointer-events: none

### DIFF
--- a/src/scss/themes/_video.scss
+++ b/src/scss/themes/_video.scss
@@ -34,6 +34,7 @@
 
 		&:after {
 			@include oIconsGetIcon('play', oColorsGetPaletteColor('white'), 30, $apply-width-height: false);
+			pointer-events: none;
 			content: '';
 			position: absolute;
 			bottom: 0;


### PR DESCRIPTION
We had a bug reported to the next team that the play buttons on https://www.ft.com/video and https://www.ft.com/ft-features could not be clicked. I have implemented a fix for this. 

The ticket for this issue:

https://trello.com/c/E2V0g94b/284-you-cant-actually-click-the-play-button-on-the-video-page-%F0%9F%A4%A3