### PR TITLE
Fix teaser tags so suffix is separated from prefix

### DIFF
--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -67,7 +67,7 @@
 	color: inherit;
 	text-decoration: none;
 	border: 0;
-	margin: 0 0.25em;
+	margin-right: 0.25em;
 
 	&:hover,
 	&:focus {
@@ -77,15 +77,10 @@
 	span {
 		display: inline-block;
 	}
-
-	// Remove margin if there is no prefix
-	&:first-child {
-		margin-left: 0;
-	}
 }
 
 @mixin oTeaserTagPrefix {
-	// Placeholder for future use
+	margin-right: 0.25em;
 }
 
 @mixin oTeaserTagSuffix {


### PR DESCRIPTION
Adding margin to the right of the suffix rather than using first
child stops the suffix from butting against the prefix if there is no teaser tag present.

Issue raised via Consumer Products Ops Cops https://trello.com/c/Lxzbf3wD/677-no-space-between-tag-and-time