### PR TITLE
fix promoted-content font weight

### DIFF
--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -20,6 +20,7 @@
 
 	.o-teaser__promoted-prefix {
 		@include oLabelsContent($opts: ('state': 'content-commercial', 'base': true, 'size': 'small'));
+		@include oTypographyBold('sans');
 	}
 }
 
@@ -39,5 +40,6 @@
 
 	.o-teaser__promoted-prefix {
 		@include oLabelsContent($opts: ('state': 'content-commercial', 'base': true, 'size': 'small'));
+		@include oTypographyBold('sans');
 	}
 }


### PR DESCRIPTION
Not sure of whether this way is the most appropriate please feel free to amend.

The promoted label in white text should be bold.

It seems like between o-labels 3 and 4 we had a regression on promoted content labels where the font inherits from the base label style instead of the more specific font-weight that the meta prefix should have. 

Here are screenshots of the problem on native ads

Front page with o-labels `3.x.x`
![](https://puu.sh/D5BSG/d2a91087a8.png)

Stream page with o-labels `4.x.x`
![](https://puu.sh/D5BSU/b361770275.png)