### PR TITLE
fix: remove style that hide the stand first in the video teaser

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -200,7 +200,8 @@
 				"article-tag": "New York Minute",
 				"article-duration": "4:15min",
 				"article-heading": "Future energy in Scottish mountains",
-				"article-timestamp": "2016-02-29T12:35:48Z"
+				"article-timestamp": "2016-02-29T12:35:48Z",
+				"article-standfirst": "Bondholders pay government for the privilege of lending it money"
 			}
 		},
 		{
@@ -215,7 +216,8 @@
 				"article-duration": "4:15min",
 				"article-heading": "Future energy in Scottish mountains",
 				"article-timestamp": "2016-02-29T12:35:48Z",
-				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo"
+				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
+				"article-standfirst": "Bondholders pay government for the privilege of lending it money"
 			}
 		},
 		{
@@ -511,7 +513,8 @@
 				"article-duration": "4:15min",
 				"article-heading": "Future energy in Scottish mountains",
 				"article-timestamp": "2016-02-29T12:35:48Z",
-				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo"
+				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
+				"article-standfirst": "Bondholders pay government for the privilege of lending it money"
 			}
 		},
 		{

--- a/src/scss/themes/_video.scss
+++ b/src/scss/themes/_video.scss
@@ -23,11 +23,6 @@
 		}
 	}
 
-	// always hide the standfirst
-	.o-teaser__standfirst {
-		display: none;
-	}
-
 	// Add play icon overlay for image
 	.o-teaser__image-placeholder {
 		position: relative;


### PR DESCRIPTION
[Bug ticket](https://trello.com/c/Nt7gAdsK/804-standfirst-missing-on-video)

## Issue:

The standfirst doesn't display in a video teaser.

As mentioned in [this chat](https://financialtimes.slack.com/archives/C042NBBTM/p1554220839117200) we are conscious that this is a breaking change and more than bug sounds like a `change request`.
Anyway, Editorial is requesting this change and we can proceed.
After a discussion with @i-like-robots and @rowanbeentje we decided that there won't be any impact on releasing this as a minor, rather than as a Major as it should be, cause [the consumers of the component are all known and accept the change](https://financialtimes.slack.com/archives/C042NBBTM/p1554306641151200?thread_ts=1554220839.117200&cid=C042NBBTM).

## Before the changes from the Origami Demo:

<img width="636" alt="Screenshot 2019-04-03 at 16 36 47" src="https://user-images.githubusercontent.com/752680/55496777-b4eafd80-5637-11e9-8a8e-694e84aa5639.png">
<img width="624" alt="Screenshot 2019-04-03 at 16 36 56" src="https://user-images.githubusercontent.com/752680/55496792-bddbcf00-5637-11e9-81b0-f018675c75b2.png">

## After the changes from local env (Screenshots from the Mocks):

There are 4 example affected but the standfirst was present already in the stacked one.

![Screenshot 2019-04-03 at 17 23 46](https://user-images.githubusercontent.com/752680/55496834-d4822600-5637-11e9-831a-9af81a35d1ab.png)
<img width="462" alt="Screenshot 2019-04-03 at 17 23 05" src="https://user-images.githubusercontent.com/752680/55496851-dc41ca80-5637-11e9-86ea-2e87ac957749.png">
<img width="1411" alt="Screenshot 2019-04-03 at 17 23 36" src="https://user-images.githubusercontent.com/752680/55496862-e368d880-5637-11e9-9e08-b7aa84adfcad.png">
![Screenshot 2019-04-03 at 17 50 02](https://user-images.githubusercontent.com/752680/55497318-0647bc80-5639-11e9-9add-5cb3736275c8.png)





