### PR TITLE
Add audio icon for audio teaser small

### DIFF
--- a/src/scss/themes/_audio.scss
+++ b/src/scss/themes/_audio.scss
@@ -1,4 +1,28 @@
 @mixin oTeaserAudio {
+	.o-teaser__heading:before {
+		@include oIconsGetIcon('audio', oColorsGetPaletteColor('white'), 15, $apply-width-height: false);
+		content: '';
+		width: 0.7em;
+		height: 0.7em;
+		min-width: 12px;
+		min-height: 12px;
+		margin-right: 0.15em;
+		background-color: oColorsGetPaletteColor('slate');
+
+	}
+
+	// hide the title prefix icon if there is an image...
+	&.o-teaser--has-image .o-teaser__heading:before {
+		content: none;
+	}
+
+	// ...except for when the image is hidden on small teasers on narrow viewports
+	&.o-teaser--has-image.o-teaser--small .o-teaser__heading:before {
+		@include oGridRespondTo($until: 'M') {
+			content: '';
+		}
+	}
+
 	// Add audio icon overlay for image
 	.o-teaser__image-placeholder {
 		position: relative;


### PR DESCRIPTION
Until M layout size, audio teasers need to display audio icon before the title like video teasers' play icon.

![add-audio-icon-small-teaser](https://user-images.githubusercontent.com/21194161/55622295-addb0100-5797-11e9-8d1c-e5f269145352.png)
