### PR TITLE
Add live demo

### DIFF
--- a/origami.json
+++ b/origami.json
@@ -33,6 +33,18 @@
 			}
 		},
 		{
+			"title": "Small Live",
+			"name": "small-live",
+			"description": "Small live teaser",
+			"template": "demos/src/demo.mustache",
+			"data": {
+				"article-modifier": "live",
+				"article-tag": "World",
+				"article-heading": "Japan sells negative yield 10-year bonds",
+				"article-timestamp": "2016-02-29T12:35:48Z"
+			}
+		},
+		{
 			"title": "Small Full Fat",
 			"name": "small-full-fat",
 			"description": "Small (full-fat) teaser",


### PR DESCRIPTION
We appear to be missing a demo for this kind of teaser:
<img width="433" alt="Screenshot 2019-04-15 at 16 58 40" src="https://user-images.githubusercontent.com/10405691/56147240-c8835600-5f9f-11e9-9402-b8a54c043a3d.png">