### PR TITLE
Decrease the opacity of the hover/visited text

### DIFF
--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -65,7 +65,7 @@
 		a:hover,
 		a:visited,
 		&:focus {
-			@include oColorsFor(o-teaser-package-special-report, text, 73);
+			@include oColorsFor(o-teaser-package-special-report, text, 78);
 		}
 	}
 }
@@ -150,7 +150,7 @@
 			color: oColorsGetPaletteColor('white');
 
 			&:hover {
-				@include oColorsFor(o-teaser-package-special-report, text, 73);
+				@include oColorsFor(o-teaser-package-special-report, text, 78);
 			}
 		}
 


### PR DESCRIPTION
At 73 this text does not pass colour contrast for WCAGAA. (Ratio is 4.15)
This change deceases the opacity so we pass WCAGAA (Ratio is now 4.48)

This should be a minor or patch version bump. I did it primarily to fix the noisy
build process for next-article which pollutes the console with oColors
warnings.