### PR TITLE
Fix accessiblity border on o-teaser image container

### DIFF
--- a/src/scss/themes/_video.scss
+++ b/src/scss/themes/_video.scss
@@ -42,6 +42,11 @@
 			background-color: oColorsGetPaletteColor('slate');
 		}
 	}
+
+	.o-teaser__image-container a {
+		display: block;
+		border: 0;
+	}
 }
 
 @mixin oTeaserBigVideo {


### PR DESCRIPTION
For video teasers there is a anchor wrapped around the image. This was
not showing the teal accessibility border when it was tabbed too.
Making the anchor display block gives the link the right dimensions
which displays the border correctly.

<img width="424" alt="Screenshot 2019-05-23 at 16 07 55" src="https://user-images.githubusercontent.com/1721150/58263964-f3b64d80-7d74-11e9-8252-87f2ac046c41.png">