### PR TITLE
Ensure the display block only happens on focus

### DIFF
--- a/src/scss/themes/_video.scss
+++ b/src/scss/themes/_video.scss
@@ -43,7 +43,7 @@
 		}
 	}
 
-	.o-teaser__image-container a {
+	.o-teaser__image-container a:focus {
 		display: block;
 		border: 0;
 	}


### PR DESCRIPTION
https://trello.com/c/GWfXSKp9/939-in-situ-video-player-on-homepage-is-showing-an-image-and-the-video

this style was more specific than .`n-ui-hide-enhanced` and therefore there were 2 things showing up when this should have been hidden