### PR TITLE
Revert "Overflow improvements"

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -45,6 +45,9 @@
 }
 
 @mixin oTeaserElementsDefault {
+	.o-teaser__meta {
+		@include oTeaserMeta;
+	}
 
 	.o-teaser__tag-prefix {
 		@include oTeaserTagPrefix;
@@ -52,10 +55,6 @@
 
 	.o-teaser__tag {
 		@include oTeaserTag;
-	}
-
-	.o-teaser__meta {
-		@include oTeaserMeta;
 	}
 
 	.o-teaser__tag-suffix {

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -44,9 +44,6 @@
 @mixin oTeaserMeta {
 	@include oTypographySize(0, 20px);
 	@include oColorsFor('o-teaser-tag', 'text');
-	display: flex;
-	flex-wrap: wrap;
-	word-break: break-word;
 }
 
 /// Tag styling.

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -6,6 +6,7 @@
 	.o-teaser__content {
 		@include oColorsFor('o-teaser-hero', background);
 		border: 0;
+		word-break: break-word;
 	}
 
 	.o-teaser__meta:after {
@@ -157,10 +158,6 @@
 @mixin oTeaserHeroCentre {
 	.o-teaser__content {
 		text-align: center;
-	}
-
-	.o-teaser__meta {
-		justify-content: center;
 	}
 
 	.o-teaser__meta:after {


### PR DESCRIPTION
Reverts Financial-Times/o-teaser#138

It didn't account for the hero underscore which is a flex child
<img width="612" alt="Screenshot 2019-11-04 at 14 41 18" src="https://user-images.githubusercontent.com/10405691/68129444-7b51dc00-ff11-11e9-9697-2e182df4c6c5.png">
