### PR TITLE
Correct the colour of the inversed tag prefix.

### DIFF
--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -13,7 +13,7 @@
 	}
 
 	.o-teaser__meta,
-	.o-teaser__duration,
+	.o-teaser__tag-suffix,
 	.o-teaser__heading {
 		color: oColorsByName('white');
 	}


### PR DESCRIPTION
The element `o-teaser__tag-suffix` has never been coloured correctly
for teaser variants which changes the teaser background colour,
like the opinion teaser. We never noticed because `o-teaser__duration`
was mostly used (but deprecated in favour of a more generic
`o-teaser__tag-suffix`). In the last major we removed
`o-teaser__duration` but:

- a: didn't notice `o-teaser__tag-suffix` had an incorrect colour
in some cases
- b: missed a `o-teaser__duration` css selector

Fixes: https://github.com/Financial-Times/o-teaser/issues/149

Before
![Screen Shot 2020-02-19 at 17 27 26](https://user-images.githubusercontent.com/10405691/74858820-ddf2aa80-533d-11ea-8a14-031b3583b4e1.png)

After
![Screen Shot 2020-02-19 at 17 33 10](https://user-images.githubusercontent.com/10405691/74858859-ea770300-533d-11ea-9e7c-fea753f6c865.png)
