### PR TITLE
Restore some text colours to how they were in v3

### DIFF
--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -50,13 +50,13 @@
 	.o-teaser__standfirst a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
-		color: oColorsMix($opinion-color, $percentage: 73);
+		color: oColorsMix($opinion-color, $opinion-background, $percentage: 73);
 	}
 
 	.o-teaser__standfirst,
 	.o-teaser__timestamp,
 	.o-teaser__timestamp-prefix:before {
-		color: oColorsMix($opinion-color, $percentage: 80);
+		color: oColorsMix($opinion-color, $opinion-background, $percentage: 80);
 	}
 
 	.o-teaser__timestamp-prefix:before {
@@ -222,13 +222,13 @@
 	.o-teaser__standfirst {
 		color: oColorsByName('white');
 		a:visited {
-			color: oColorsMix($hero-extra-color, $percentage: 50);
+			color: oColorsMix($hero-extra-color, $hero-extra-background, $percentage: 50);
 		}
 	}
 
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {
-		color: oColorsMix($hero-extra-color, $percentage: 80);
+		color: oColorsMix($hero-extra-color, $hero-extra-background, $percentage: 80);
 	}
 
 	.o-teaser__image-container:after,

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -66,7 +66,8 @@
 		a:visited,
 		&:focus {
 			$special-report-color: oColorsByUsecase('o-teaser/package-special-report', 'text');
-			color: oColorsMix($special-report-color, $percentage: 78);
+			$special-report-background: oColorsByUsecase('o-teaser/package-special-report', 'background');
+			color: oColorsMix($special-report-color, $special-report-background, $percentage: 78);
 		}
 	}
 }
@@ -131,8 +132,12 @@
 		&__landing-link a {
 			color: oColorsByUsecase('o-teaser/package-basic', 'text');
 
-			&:hover {
-				color: oColorsByUsecase('o-teaser/package-basic', 'text');
+			&:hover,
+			&:visited,
+			&:focus {
+				$special-report-color: oColorsByUsecase('o-teaser/package-special-report', 'text');
+				$special-report-background: oColorsByUsecase('o-teaser/package-special-report', 'background');
+				color: oColorsMix($special-report-color, $special-report-background, $percentage: 78);
 			}
 
 			&:after {
@@ -148,16 +153,17 @@
 @mixin _oTeaserSpecialReportPackageList {
 	.package-teaser {
 		$package-special-report-color: oColorsByUsecase('o-teaser/package-special-report', 'text');
+		$package-special-report-background: oColorsByUsecase('o-teaser/package-special-report', 'background');
 		&__list-item a {
 			color: oColorsByName('white');
 
 			&:hover {
-				color: oColorsMix($package-special-report-color, $percentage: 78);
+				color: oColorsMix($package-special-report-color, $package-special-report-background, $percentage: 78);
 			}
 		}
 
 		&__landing-link a {
-			color: oColorsMix($package-special-report-color, $percentage: 80);
+			color: oColorsMix($package-special-report-color, $package-special-report-background, $percentage: 80);
 
 			&:hover {
 				color: oColorsByName('white');

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -1,6 +1,7 @@
 /// Inverse theme styles - base all text content on white
 @mixin _oTeaserInverse {
 	$inverse-color: oColorsByUsecase('o-teaser/inverse', 'text');
+	$inverse-background: oColorsByUsecase('o-teaser/inverse', 'background');
 	.o-teaser__heading a:hover,
 	.o-teaser__heading a:focus,
 	.o-teaser__heading a:visited,
@@ -9,7 +10,7 @@
 	.o-teaser__standfirst a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
-		color: oColorsMix($inverse-color, $percentage: 60);
+		color: oColorsMix($inverse-color, $inverse-background, $percentage: 60);
 	}
 
 	.o-teaser__meta,
@@ -20,7 +21,7 @@
 
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {
-		color: oColorsMix($inverse-color, $percentage: 70);
+		color: oColorsMix($inverse-color, $inverse-background, $percentage: 60);
 	}
 
 	&.o-teaser--hero .o-teaser__meta:after {
@@ -60,7 +61,7 @@
 	$theme-opinion-background: oColorsByUsecase('o-teaser/theme-opinion', 'background');
 	.o-teaser__standfirst,
 	.o-teaser__timestamp {
-		color: oColorsMix($theme-opinion-color, $percentage: 60);
+		color: oColorsMix($theme-opinion-color, $theme-opinion-background, $percentage: 60);
 	}
 
 	&.o-teaser--large {
@@ -94,13 +95,13 @@
 	.o-teaser__standfirst a:visited,
 	.o-teaser__tag:hover,
 	.o-teaser__tag:focus {
-		color: oColorsMix($theme-highlight-color, $percentage: 73);
+		color: oColorsMix($theme-highlight-color, $theme-highlight-background, $percentage: 73);
 	}
 
 	.o-teaser__standfirst,
 	.o-teaser__timestamp,
 	.o-teaser__timestamp-prefix:before {
-		color: oColorsMix($theme-highlight-color, $percentage: 80);
+		color: oColorsMix($theme-highlight-color, $theme-highlight-background, $percentage: 80);
 	}
 
 	.o-teaser__timestamp-prefix:before {


### PR DESCRIPTION
During the migration to o-colors v5, we replaced `oColorsFor`
for `oColorsMix` when generating text colours. But instead of
mixing with the text background we mixed with paper.

Relates to: https://github.com/Financial-Times/o-teaser/pull/147

Mostly the difference is not obvious. For example a slightly brighter standfirst,
which is arguably a good thing actually (before/after):
![Screen Shot 2020-02-19 at 18 31 04](https://user-images.githubusercontent.com/10405691/74863966-ac321180-5346-11ea-8348-135c5eff3438.png)
![Screen Shot 2020-02-19 at 18 30 53](https://user-images.githubusercontent.com/10405691/74864056-cf5cc100-5346-11ea-9d66-379e4f8290d7.png)

But has caused some bigger issues like the visited state of this link 😱 
![Screen Shot 2020-02-19 at 18 32 24](https://user-images.githubusercontent.com/10405691/74864108-e69bae80-5346-11ea-9807-4e6ba06d38b3.png)

_Now most of the o-teaser interface is private it could really use a refactor (at least)_