### PR TITLE
Font changes for articles and meta data

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,9 @@
 # Migration guide
 
+## Migrating from v4 to v5
+
+v5 introduces the font FinancierDisplayWeb at medium weight and normal style. To upgrade make sure your project includes the FinancierDisplayWeb medium font face using [o-fonts](https://registry.origami.ft.com/components/o-fonts).
+
 ## Migrating from v3 to v4
 
 ### Colours and Colour Usecases

--- a/README.md
+++ b/README.md
@@ -164,8 +164,9 @@ Uses the `o-teaser--audio` modifier.
 
 State | Major Version | Last Minor Release | Migration guide |
 :---: | :---: | :---: | :---:
-✨ active | 4 | N/A  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
-⚠ maintained | 3 | 3.5  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
+✨ active | 5 | N/A  | [migrate to v5](MIGRATION.md#migrating-from-v4-to-v5) |
+⚠ maintained | 4 | 4.0  | [migrate to v4](MIGRATION.md#migrating-from-v3-to-v4) |
+╳ deprecated | 3 | 3.5  | [migrate to v3](MIGRATION.md#migrating-from-v2-to-v3) |
 ╳ deprecated | 2 | 2.5  | [migrate to v2](MIGRATION.md#migrating-from-v1-to-v2) |
 ╳ deprecated | 1 | 1.9 | - |
 

--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "o-colors": "^5.0.0",
-    "o-typography": "^6.0.0",
+    "o-typography": "^6.2.0",
     "o-grid": "^5.0.0",
     "o-icons": "^6.0.0",
     "o-labels": "^5.0.0",

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -7,7 +7,7 @@
 	color: $_o-teaser-base-color;
 	margin-top: 0;
 	margin-bottom: 0;
-	font-weight: oFontsWeight(normal);
+	font-weight: oFontsWeight(medium);
 }
 
 

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -68,8 +68,8 @@
 }
 
 @mixin _oTeaserTagPrefix {
-	margin-right: 0.25em;
 	@include oTypographySans($weight: 'semibold');
+	margin-right: 0.25em;
 }
 
 @mixin _oTeaserTagSuffix {

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -51,7 +51,7 @@
 /// Tag styling.
 /// Element should be a link, otherwise use _oTeaserMeta
 @mixin _oTeaserTag {
-	@include oTypographySans($weight: 'semibold', $include-font-family: false);
+	@include oTypographySans($weight: 'regular', $include-font-family: false);
 	color: inherit;
 	text-decoration: none;
 	border: 0;
@@ -69,6 +69,7 @@
 
 @mixin _oTeaserTagPrefix {
 	margin-right: 0.25em;
+	@include oTypographySans($weight: 'semibold');
 }
 
 @mixin _oTeaserTagSuffix {

--- a/src/scss/themes/_large.scss
+++ b/src/scss/themes/_large.scss
@@ -9,7 +9,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographySans($scale: 4);
+		@include oTypographySerif($scale: 4);
 	}
 
 	.o-teaser__timestamp {

--- a/src/scss/themes/_large.scss
+++ b/src/scss/themes/_large.scss
@@ -10,6 +10,7 @@
 
 	.o-teaser__heading {
 		@include oTypographySerif($scale: 4);
+		font-family: FinancierDisplayWeb, serif;
 	}
 
 	.o-teaser__timestamp {

--- a/src/scss/themes/_large.scss
+++ b/src/scss/themes/_large.scss
@@ -9,7 +9,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographyDisplay($scale: 4);
+		@include oTypographyDisplay($scale: 3);
 	}
 
 	.o-teaser__timestamp {

--- a/src/scss/themes/_large.scss
+++ b/src/scss/themes/_large.scss
@@ -9,8 +9,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographySerif($scale: 4);
-		font-family: FinancierDisplayWeb, serif;
+		@include oTypographyDisplay($scale: 4);
 	}
 
 	.o-teaser__timestamp {

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -30,7 +30,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographySans(4);
+		@include oTypographySerif(4);
 		color: $_o-teaser-base-color;
 		background: inherit;
 		padding: 20px;

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -30,8 +30,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographySerif(4);
-		font-family: FinancierDisplayWeb, serif;
+		@include oTypographyDisplay($scale: 4);
 		color: $_o-teaser-base-color;
 		background: inherit;
 		padding: 20px;

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -31,6 +31,7 @@
 
 	.o-teaser__heading {
 		@include oTypographySerif(4);
+		font-family: FinancierDisplayWeb, serif;
 		color: $_o-teaser-base-color;
 		background: inherit;
 		padding: 20px;

--- a/src/scss/themes/_top-stories.scss
+++ b/src/scss/themes/_top-stories.scss
@@ -6,7 +6,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographyDisplay($scale: (default: (5, 1), L: (6)));
+		@include oTypographyDisplay($scale: (default: (5, 1), L: (7)));
 	}
 
 	.o-teaser__standfirst {

--- a/src/scss/themes/_top-stories.scss
+++ b/src/scss/themes/_top-stories.scss
@@ -6,7 +6,7 @@
 	}
 
 	.o-teaser__heading {
-		@include oTypographyDisplay($scale: (default: (5, 1), L: (7)));
+		@include oTypographyDisplay($scale: (default: (5, 1), L: (6)));
 	}
 
 	.o-teaser__standfirst {


### PR DESCRIPTION
Style changes are based on new design requirements described in 
https://financialtimes.atlassian.net/browse/AT-3576
Note, that requirements have changed slightly

Implications on o-teaser are now the following: 

1) All headings now have Financier medium font
2) Meta tag uses regular weight, while meta prefix tag uses semibold weight
3) Large teaser will be scaled to use 24px/28px font size

the rest of the changes (hero teasers and landscape top story) will be done on ft-app side because of view differences on both projects - ft.com and apps

Design changes were reviewed and approved by Mark Limb