### PR TITLE
Increase size for centred hero heading

### DIFF
--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -162,6 +162,10 @@
 		text-align: center;
 	}
 
+	.o-teaser__heading {
+		@include oTypographyDisplay($scale: 4);
+	}
+
 	.o-teaser__meta:after {
 		margin-left: auto;
 		margin-right: auto;


### PR DESCRIPTION
As a part of fonts changes, we need to slightly increase the size of the centered hero teaser. This particular change will affect ft.com only as in Apps we have our own overwrite design for hero teasers. Please, see Mark's comment in https://financialtimes.atlassian.net/browse/AT-3576 

Mark Limb said:

After discussing the fonts with Olga Averjanova, specifically the headers for the 3 bears  on ft.com we agreed to use: 

Origami type scale 4
28px / 32px line height

<img width="854" alt="Screenshot 2020-04-22 at 17 37 46" src="https://user-images.githubusercontent.com/14136353/80009017-63224900-84c0-11ea-8c5d-7dcdd16c36a9.png">

