### PR TITLE
Update teaser spacing

### DIFF
--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -87,14 +87,13 @@
 	margin-bottom: 0;
 
 	.o-teaser__heading + & {
-		margin-top: 10px;
+		margin-top: oSpacingByName('s2');
 	}
 }
 
 /// Links within title or standfirst
 @mixin _oTeaserLink {
 	a {
-		padding: 2px 0;
 		color: inherit;
 		text-decoration: none;
 		border: 0;

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -46,6 +46,7 @@
 @mixin _oTeaserMeta {
 	@include oTypographySans(0, $include-font-family: false);
 	color: oColorsByUsecase('o-teaser/tag', 'text');
+	margin-bottom: oSpacingByName('s1');
 }
 
 /// Tag styling.

--- a/src/scss/elements/_default.scss
+++ b/src/scss/elements/_default.scss
@@ -44,7 +44,7 @@
 
 /// Meta area and colouring styles
 @mixin _oTeaserMeta {
-	@include oTypographySans(0, 20px, $include-font-family: false);
+	@include oTypographySans(0, $include-font-family: false);
 	color: oColorsByUsecase('o-teaser/tag', 'text');
 }
 

--- a/src/scss/elements/_timestamp.scss
+++ b/src/scss/elements/_timestamp.scss
@@ -1,13 +1,13 @@
 /// Timestamp base styles
 @mixin _oTeaserTimestamp {
-	@include oTypographySans(-2, 20px, $include-font-family: false);
+	@include oTypographySans(-2, $include-font-family: false);
 	color: $_o-teaser-muted;
 	display: block;
+	// Moves timestamp to the bottom when stretched modifier is used
+	margin-top: auto;
+	// and ensures there is always some gap above
+	padding-top: oSpacingByName('s4');
 	text-transform: uppercase;
-
-	.o-teaser__heading + &:not(:empty) {
-		margin-top: 5px;
-	}
 }
 
 /// Timestamp variant styles adding coloured prefixes.
@@ -53,7 +53,7 @@
 
 		&:before {
 			position: absolute;
-			top: 5px;
+			top: oSpacingByName('s4') + 3;
 			opacity: 0.2;
 			transform: scale(1.5);
 			animation: live-blog-pulse 1.7s ease infinite;

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -15,7 +15,7 @@
 		width: 60px;
 		border-bottom: oSpacingByIncrement(1) solid oColorsByName('claret');
 		margin-top: oSpacingByName('s1');
-		margin-bottom: oSpacingByName('s3');
+		margin-bottom: oSpacingByName('s2');
 	}
 }
 

--- a/src/scss/themes/_large.scss
+++ b/src/scss/themes/_large.scss
@@ -12,10 +12,6 @@
 		@include oTypographyDisplay($scale: 3);
 	}
 
-	.o-teaser__timestamp {
-		margin-top: oSpacingByName('s1');
-	}
-
 	.o-teaser__standfirst {
 		@include oTypographySans(
 			$scale: (default: (1, 24px), L: (2, 24px)),

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -43,6 +43,11 @@
         }
         .o-teaser__timestamp {
             order: -1;
+            padding-top: 0;
+
+            &:before {
+              top: 3px;
+            }
         }
         .o-teaser__timestamp time {
             display: none;

--- a/src/scss/themes/_package.scss
+++ b/src/scss/themes/_package.scss
@@ -34,7 +34,7 @@
 		color: $_o-teaser-base-color;
 		background: inherit;
 		padding: 20px;
-		margin-top: -52px;
+		margin-top: -55px;
 		width: 100%;
 
 		a:hover,

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -1,7 +1,7 @@
 /// Small teaser styles
 @mixin _oTeaserSmall {
 	display: flex;
-	padding-bottom: oSpacingByName('s4');
+	padding-bottom: oSpacingByName('s3');
 	border-bottom: 1px solid oColorsByUsecase('o-teaser/base', 'border');
 
 	.o-teaser__content {

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -14,7 +14,6 @@
 		width: 30%;
 		// because flex items are allowed to shrink implicitly
 		flex-shrink: 0;
-		padding-top: 4px; // to line up with tag cap-height
 		padding-right: oGridGutter(M);
 
 		@include oGridRespondTo($until: M) { // Mobile screens only

--- a/src/scss/themes/_small.scss
+++ b/src/scss/themes/_small.scss
@@ -37,7 +37,7 @@
 	}
 
 	.o-teaser__image-container {
-		margin-bottom: 16px;
+		margin-bottom: oSpacingByName('s3');
 		width: 100%;
 		// <https://connect.microsoft.com/IE/feedbackdetail/view/891815>
 		min-height: 1px;

--- a/src/scss/themes/_standard.scss
+++ b/src/scss/themes/_standard.scss
@@ -30,8 +30,8 @@
 }
 
 /// Make a teaser fill the full height of its container
-/// (if the container is flex) and stretch the heading to
-/// move standfirst and timestamp to teaser footer
+/// (if the container is flex) and stretch the content to
+/// move timestamp to teaser footer
 @mixin _oTeaserStretched {
 	display: flex;
 	flex-grow: 1;
@@ -41,10 +41,6 @@
 		flex-direction: column;
 		flex-grow: 1;
 		flex-basis: auto;
-	}
-
-	.o-teaser__heading {
-		flex-grow: 1;
 	}
 }
 

--- a/src/scss/themes/_top-stories.scss
+++ b/src/scss/themes/_top-stories.scss
@@ -17,7 +17,7 @@
 /// Standalone top story theme styles
 @mixin _oTeaserTopStoryStandalone {
 	.o-teaser__image-container {
-		margin-bottom: 20px;
+		margin-bottom: oSpacingByName('s3');
 	}
 }
 


### PR DESCRIPTION
These changes update margins & paddings in teasers to match updated designs. They should all apply to both the app and dotcom with no issues. Most of them are little tweaks and difficult to notice with the naked eye.

Apps ticket: [AT-3263](https://financialtimes.atlassian.net/browse/AT-3263)

The biggest change I guess is on the `stretched` modifier. Instead of moving both standfirst & timestamp, it will now only move the timestamp to the bottom - if there is one. Again, this probably won't look too different in most cases but I think there will be further work to make the timestamp permanent.

Stretch effect is not seen best on demo item, so took a screen grab from dotcom.

Current:
<img width="493" alt="Screenshot 2020-04-24 at 10 45 25" src="https://user-images.githubusercontent.com/1024116/80199881-b9ef6600-8619-11ea-8ee5-951fa711051b.png">

After v5:
<img width="494" alt="Screenshot 2020-04-24 at 10 43 40" src="https://user-images.githubusercontent.com/1024116/80199921-c7a4eb80-8619-11ea-8724-eb3238ef00de.png">

The other obvious change is the removal of `padding-top` from image in `small`. This was being applied to align image top with the topic.

Before:
<img width="482" alt="Screenshot 2020-04-23 at 07 42 31" src="https://user-images.githubusercontent.com/1024116/80200429-87923880-861a-11ea-8249-9d4d75346971.png">

After:
<img width="475" alt="Screenshot 2020-04-23 at 07 43 03" src="https://user-images.githubusercontent.com/1024116/80200441-8bbe5600-861a-11ea-8a32-fec317e7dde9.png">

Other examples:

Small before:
<img width="416" alt="Screenshot 2020-04-24 at 11 03 05" src="https://user-images.githubusercontent.com/1024116/80200991-59f9bf00-861b-11ea-9860-0444bacd35f4.png">

Small after:
<img width="415" alt="Screenshot 2020-04-24 at 11 03 15" src="https://user-images.githubusercontent.com/1024116/80201005-5ebe7300-861b-11ea-9d8a-c7d1b42c8ece.png">

Small stacked before:
<img width="421" alt="Screenshot 2020-04-24 at 11 04 46" src="https://user-images.githubusercontent.com/1024116/80201076-7c8bd800-861b-11ea-8f06-2a5ec2b4932a.png">

Small stacked after:
<img width="419" alt="Screenshot 2020-04-24 at 11 05 00" src="https://user-images.githubusercontent.com/1024116/80201096-84e41300-861b-11ea-8369-14153d82b8eb.png">

Package before:
<img width="398" alt="Screenshot 2020-04-24 at 11 10 05" src="https://user-images.githubusercontent.com/1024116/80201613-4f8bf500-861c-11ea-8b09-e8a9a1c25c98.png">

Package after:
<img width="399" alt="Screenshot 2020-04-24 at 11 10 13" src="https://user-images.githubusercontent.com/1024116/80201624-531f7c00-861c-11ea-843b-1d2146308f7a.png">

