### PR TITLE
Deprecate `.o-teaser__timestamp--inprogress` for `--live`

### DIFF
--- a/demos/src/demo-large.mustache
+++ b/demos/src/demo-large.mustache
@@ -21,7 +21,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-			<div class="o-teaser__timestamp {{#is-live}}o-teaser__timestamp--inprogress{{/is-live}}">
+			<div class="o-teaser__timestamp {{#is-live}}o-teaser__timestamp--live{{/is-live}}">
 				{{#is-live}}<span class="o-teaser__timestamp-prefix">Live</span>{{/is-live}}
 				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			</div>

--- a/demos/src/demo-syndi.mustache
+++ b/demos/src/demo-syndi.mustache
@@ -31,7 +31,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -31,7 +31,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -15,7 +15,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
@@ -45,7 +45,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
@@ -68,7 +68,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
@@ -99,7 +99,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
@@ -406,7 +406,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
@@ -442,7 +442,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--inprogress">
+				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
 					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>

--- a/src/scss/elements/_timestamp.scss
+++ b/src/scss/elements/_timestamp.scss
@@ -25,7 +25,10 @@
 		@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'updated'));
 	}
 
-	.o-teaser__timestamp--inprogress {
+	// @deprecated - o-teaser__timestamp--inprogress has been replaced by o-teaser__timestamp--live
+	// https://github.com/Financial-Times/o-teaser/issues/173
+	.o-teaser__timestamp--inprogress,
+	.o-teaser__timestamp--live {
 		@include oLabelsIndicatorContent($opts: ('block': true, 'modifier': 'live'));
 	}
 

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -30,8 +30,12 @@
 			}
 		}
 
+
+		// @deprecated - o-teaser__timestamp--inprogress has been replaced by o-teaser__timestamp--live
+		// https://github.com/Financial-Times/o-teaser/issues/173
 		.o-teaser__timestamp-prefix:before,
-		.o-teaser__timestamp--inprogress:before {
+		.o-teaser__timestamp--inprogress:before,
+		.o-teaser__timestamp--live:before {
 			background-color: white;
 		}
 	}


### PR DESCRIPTION
This change was made for two reasons:
1. it matches the naming [in `o-labels`](https://github.com/Financial-Times/o-labels/tree/v5.1.0#indicator-label)
2. users are already using [the `live` modifier](https://github.com/Financial-Times/x-dash/blob/b196dc20a09b861fce69e4e50fc77f3105f948b7/components/x-teaser/src/LiveBlogStatus.jsx#L10)

The `.o-teaser__timestamp--inprogress` selector should be removed in the next major release.
https://github.com/Financial-Times/o-teaser/issues/173