### PR TITLE
V5 partner content

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,13 @@ The basic markup structure for a teaser will look something like this:
 		<a href="#" class="o-teaser__tag">World</a>
 		<h2 class="o-teaser__heading"><a href="#">Japan sells negative yield 10-year bonds</a></h2>
 		<div class="o-teaser__timestamp">
-			<time data-o-component="o-date" class="o-date" datetime="2016-02-29T12:35:48Z">2016-02-29T12:35:48Z</time>
+			<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="2016-02-29T12:35:48Z">2016-02-29T12:35:48Z</time>
 		</div>
 	</div>
 </div>
 ```
+
+Optionally include the [o-date](https://registry.origami.ft.com/components/o-date) component within your project to render a formatted date within the timestamp element `o-teaser__timestamp`. This is required to render relative timestamps e.g. "1hr ago".
 
 Teasers support a wide array of [elements](#supported-elements) and can be customised using several [themes](#themes) and should be used as required. For a full list of examples including example markup, see [o-teaser in the Registry](http://registry.origami.ft.com/components/o-teaser).
 

--- a/demos/src/demo-hero.mustache
+++ b/demos/src/demo-hero.mustache
@@ -21,7 +21,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 

--- a/demos/src/demo-large-modifiers.mustache
+++ b/demos/src/demo-large-modifiers.mustache
@@ -22,7 +22,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 

--- a/demos/src/demo-large.mustache
+++ b/demos/src/demo-large.mustache
@@ -23,7 +23,9 @@
 			{{#article-timestamp}}
 			<div class="o-teaser__timestamp {{#is-live}}o-teaser__timestamp--live{{/is-live}}">
 				{{#is-live}}<span class="o-teaser__timestamp-prefix">Live</span>{{/is-live}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				{{^is-live}}
+				<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				{{/is-live}}
 			</div>
 			{{/article-timestamp}}
 		</div>

--- a/demos/src/demo-syndi.mustache
+++ b/demos/src/demo-syndi.mustache
@@ -1,6 +1,6 @@
 <div class="demo-container {{#article-modifier}} demo-container--{{.}} {{/article-modifier}}">
 
-	<div class="o-teaser o-teaser--small {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
+	<div class="o-teaser o-teaser--small {{#is-live}}o-teaser--live{{/is-live}} {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
 				{{#article-tag-prefix}}<span class="o-teaser__tag-prefix">{{.}}</span>{{/article-tag-prefix}}
@@ -31,10 +31,12 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--live">
-					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
-				</div>
+			<div class="o-teaser__timestamp {{#is-live}}o-teaser__timestamp--live{{/is-live}}">
+				{{#is-live}}<span class="o-teaser__timestamp-prefix">Live</span>{{/is-live}}
+				{{^is-live}}
+				<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				{{/is-live}}
+			</div>
 			{{/article-timestamp}}
 
 			{{#article-headshot}}

--- a/demos/src/demo-top-story.mustache
+++ b/demos/src/demo-top-story.mustache
@@ -21,7 +21,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -1,6 +1,6 @@
 <div class="demo-container {{#article-modifier}} demo-container--{{.}} {{/article-modifier}}">
 
-	<div class="o-teaser o-teaser--small {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}} {{#is-live}}o-teaser--live{{/is-live}}" data-o-component="o-teaser">
+	<div class="o-teaser o-teaser--small {{#is-live}}o-teaser--stacked{{/is-live}} {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} {{#article-image-url}}o-teaser--has-image{{/article-image-url}}" data-o-component="o-teaser">
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
 				{{#article-tag-prefix}}<span class="o-teaser__tag-prefix">{{.}}</span>{{/article-tag-prefix}}

--- a/demos/src/demo.mustache
+++ b/demos/src/demo.mustache
@@ -4,7 +4,9 @@
 		<div class="o-teaser__content">
 			<div class="o-teaser__meta">
 				{{#article-tag-prefix}}<span class="o-teaser__tag-prefix">{{.}}</span>{{/article-tag-prefix}}
+				{{#article-tag}}
 				<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				{{/article-tag}}
 				{{#article-duration}}
 					<time class="o-teaser__tag-suffix" datetime="PT3M07S">3:07min</time>
 				{{/article-duration}}
@@ -31,9 +33,13 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--live">
+				<div class="o-teaser__timestamp{{#is-live}} o-teaser__timestamp--live{{/is-live}}">
+					{{#is-live}}
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					{{/is-live}}
+					{{^is-live}}
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					{{/is-live}}
 				</div>
 			{{/article-timestamp}}
 

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -15,9 +15,37 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
+				<div class="o-teaser__timestamp">
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				</div>
+			{{/article-timestamp}}
+		</div>
+		{{#article-image-url}}
+			<div class="o-teaser__image-container">
+				<div class="o-teaser__image-placeholder image-placeholder">
+					<img src="{{article-image-url}}" class="o-teaser__image" alt="demo image"/>
+				</div>
+			</div>
+		{{/article-image-url}}
+	</div>
+
+	<div class="o-teaser o-teaser--small o-teaser--stacked o-teaser--has-image o-teaser--live" data-o-component="o-teaser">
+		<div class="o-teaser__content">
+			{{#article-tag}}
+				<div class="o-teaser__meta">
+					<a href="#" class="o-teaser__tag">{{article-tag}}</a>
+				</div>
+			{{/article-tag}}
+
+			<h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
+
+			{{#article-standfirst}}
+				<p class="o-teaser__standfirst"><a href="#">{{article-standfirst}}</a></p>
+			{{/article-standfirst}}
+
+			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 		</div>
@@ -45,8 +73,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--live">
-					<span class="o-teaser__timestamp-prefix">Live</span>
+				<div class="o-teaser__timestamp">
 					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
@@ -68,8 +95,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<div class="o-teaser__timestamp o-teaser__timestamp--live">
-					<span class="o-teaser__timestamp-prefix">Live</span>
+				<div class="o-teaser__timestamp">
 					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}

--- a/demos/src/pa11y.mustache
+++ b/demos/src/pa11y.mustache
@@ -17,7 +17,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 		</div>
@@ -47,7 +47,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 		</div>
@@ -70,7 +70,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 
@@ -101,7 +101,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 
@@ -124,7 +124,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -150,7 +150,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -176,7 +176,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -202,7 +202,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -228,7 +228,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -254,7 +254,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 	</div>
@@ -272,7 +272,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 	</div>
@@ -290,7 +290,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -316,7 +316,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -373,7 +373,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -408,7 +408,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 
@@ -444,7 +444,7 @@
 			{{#article-timestamp}}
 				<div class="o-teaser__timestamp o-teaser__timestamp--live">
 					<span class="o-teaser__timestamp-prefix">Live</span>
-					<time data-o-component="o-date" class="o-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+					<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 				</div>
 			{{/article-timestamp}}
 
@@ -648,7 +648,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp-date" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -674,7 +674,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -708,7 +708,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -744,7 +744,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 
@@ -780,7 +780,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 	</div>
@@ -800,7 +800,7 @@
 			{{/article-standfirst}}
 
 			{{#article-timestamp}}
-				<time data-o-component="o-date" class="o-date o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+				<time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
 			{{/article-timestamp}}
 		</div>
 	</div>

--- a/origami.json
+++ b/origami.json
@@ -589,14 +589,14 @@
 			}
 		},
 		{
-			"title": "Paid Post",
+			"title": "Partner Content (Paid Post)",
 			"name": "paid-post",
-			"description": "Paid Post teaser",
+			"description": "Partner content",
 			"template": "demos/src/demo.mustache",
 			"hidden": false,
 			"data": {
 				"article-modifier": "paid-post",
-				"article-promoted-prefix": "Paid Post",
+				"article-promoted-prefix": "Partner Content",
 				"article-promoted-by": "E.on",
 				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
 				"article-timestamp": "2016-02-29T12:35:48Z",
@@ -607,13 +607,13 @@
 		{
 			"title": "Promoted Content",
 			"name": "promoted-content",
-			"description": "Small teaser for content by external advertisers",
+			"description": "Content by external advertisers",
 			"template": "demos/src/demo.mustache",
 			"hidden": false,
 			"data": {
 				"article-modifier": ["promoted-content", "stacked"],
 				"article-promoted-prefix": "Promoted content",
-				"article-promoted-by": "paid for by Cass Business School",
+				"article-promoted-by": "Cass Business School",
 				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
 				"article-heading": "Japan sells negative yield 10-year bonds",
 				"article-standfirst": "Bondholders pay government for the privilege of lending it money"

--- a/origami.json
+++ b/origami.json
@@ -39,6 +39,7 @@
 			"template": "demos/src/demo.mustache",
 			"data": {
 				"is-live": true,
+				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=180&source=o-teaser-demo",
 				"article-modifier": "live",
 				"article-tag": "World",
 				"article-heading": "Japan sells negative yield 10-year bonds",

--- a/origami.json
+++ b/origami.json
@@ -38,6 +38,7 @@
 			"description": "Small live teaser",
 			"template": "demos/src/demo.mustache",
 			"data": {
+				"is-live": true,
 				"article-modifier": "live",
 				"article-tag": "World",
 				"article-heading": "Japan sells negative yield 10-year bonds",

--- a/src/scss/_color-use-cases.scss
+++ b/src/scss/_color-use-cases.scss
@@ -52,14 +52,6 @@
 	'border': 'lemon',
 	'text': 'lemon'
 ));
-@include oColorsSetUseCase('o-teaser/theme-paid-post', (
-	'background': 'white',
-	'text': 'black'
-));
-@include oColorsSetUseCase('o-teaser/theme-promoted-content', (
-	'background': 'white',
-	'text': 'black'
-));
 
 // Package teasers
 @include oColorsSetUseCase('o-teaser/package-basic', (

--- a/src/scss/_deprecated.scss
+++ b/src/scss/_deprecated.scss
@@ -49,3 +49,17 @@
 		'deprecated': 'contact the Origami team if you would still like to use the o-teaser/live-blog-coming-soon colour'
 	)
 );
+
+@include oColorsSetUseCase('o-teaser/theme-paid-post', (
+	'background': 'white',
+	'text': 'black'
+), (
+	'deprecated': 'contact the Origami team if you would still like to use the o-teaser/theme-paid-post colour'
+));
+
+@include oColorsSetUseCase('o-teaser/theme-promoted-content', (
+	'background': 'white',
+	'text': 'black'
+),(
+	'deprecated': 'contact the Origami team if you would still like to use the o-teaser/theme-promoted-content colour'
+));

--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -91,12 +91,22 @@
 }
 
 @mixin _oTeaserElementsPromoted {
+	.o-teaser--promoted-content,
 	.o-teaser--paid-post {
-		@include _oTeaserPaidPost;
+		@include _oTeaserPartnerContent;
 	}
 
 	.o-teaser--promoted-content {
-		@include _oTeaserPromotedContent;
+		.o-teaser__heading a {
+			@include oTypographyLink(
+				$external: true,
+				$include-base-styles: false,
+				$theme: (
+					'base': $_o-teaser-base-color,
+					'hover': $_o-teaser-focus-hover
+				)
+			);
+		}
 	}
 }
 

--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -1,52 +1,21 @@
-/// Promoted content theme
-@mixin _oTeaserPromotedContent {
-	color: oColorsByUsecase('o-teaser/theme-promoted-content', 'text');
-	background-color: oColorsByUsecase('o-teaser/theme-promoted-content', 'background');
-	// Hack to force a higher specificity than .o-teaser--small which
-	// adds a padding-bottom of 16px. This needs to be added three times
-	// so that it has a higher specificity than
-	// .o-teaser-small.o-teaser-stacked
-	&#{&}#{&} {
-		padding: 12px;
-	}
-
-	.o-teaser__heading a {
-		@include oTypographyLink(
-			$external: true,
-			$include-base-styles: false,
-			$theme: (
-				'base': $_o-teaser-base-color,
-				'hover': $_o-teaser-focus-hover
-			)
-		);
-	}
+@mixin _oTeaserPartnerContent {
+	color: oColorsByName('black');
 
 	.o-teaser__meta {
 		@include oTypographySans($weight: 'semibold');
-		color: oColorsByName('black-80');
+		color: $_o-teaser-muted;
+		margin-bottom: oSpacingByName('s2');
 	}
 
 	.o-teaser__promoted-prefix {
-		@include oLabelsContent($opts: ('state': 'content-commercial', 'base': true, 'size': 'small'));
-	}
-}
-
-/// Paid post theme
-@mixin _oTeaserPaidPost {
-	color: oColorsByUsecase('o-teaser/theme-paid-post', 'text');
-	background-color: oColorsByUsecase('o-teaser/theme-paid-post', 'background');
-	// Hack to force a higher specificity than .o-teaser--small which
-	// adds a padding-bottom of 16px
-	&#{&} {
-		padding: 12px;
+		@include oTypographySans($scale: 0);
+		text-transform: uppercase;
+		color: oColorsByName('oxford-50');
+		display: block;
 	}
 
-	.o-teaser__meta {
-		@include oTypographySans($weight: 'semibold');
-		color: oColorsByName('black-80');
-	}
-
-	.o-teaser__promoted-prefix {
-		@include oLabelsContent($opts: ('state': 'content-commercial', 'base': true, 'size': 'small'));
+	.o-teaser__promoted-by {
+		@include oTypographySans($scale: -1, $include-font-family: false);
+		text-transform: uppercase;
 	}
 }

--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -2,20 +2,19 @@
 	color: oColorsByName('black');
 
 	.o-teaser__meta {
-		@include oTypographySans($weight: 'semibold');
+		@include oTypographySans($scale: -1, $weight: 'semibold');
 		color: $_o-teaser-muted;
 		margin-bottom: oSpacingByName('s2');
 	}
 
 	.o-teaser__promoted-prefix {
-		@include oTypographySans($scale: 0);
+		@include oTypographySans($scale: 0, $include-font-family: false);
 		text-transform: uppercase;
 		color: oColorsByName('oxford-50');
 		display: block;
 	}
 
 	.o-teaser__promoted-by {
-		@include oTypographySans($scale: -1, $include-font-family: false);
 		text-transform: uppercase;
 	}
 }


### PR DESCRIPTION
**⚠️ ready for review but do not merge:** some coordination is required to 
remove ads and globe trotter overrides

### Replace paid post labels with partner content styles.

The commercial design team created new teaser designs to replace
"paid posts" with "partner content". The ads team worked with
the commercial design team to refine requirements and rollout
the new design to ft.com with overrides:
https://github.com/Financial-Times/n-native-ads/blob/0fa02c2a685085e9a3e183672569431670eb260a/main.scss

However neither the product design team or Origami were 
involved and so the design strikes out from other teasers.
E.g. the "partner content" label no longer looks like a label
but differs from tags in that it is not a link and is uppercase.

This commit brings the overrides into Origami to:
- make maintence easier
- reduce css bundle size
- roll the changes out everywhere, including the app
- update demos and document the change, so we have a
solid base for future updates by the product design team

Some limited changes have been made from the ads overrides:
- the hover state isn't oxford, its inline with other teasers
- the "by [company name]" prefix is darker, to pass WCAG 2.0
contrast guidelines and meet DAC accreditation

These updates must be released to v4 and v5, as key pages on
ft.com is one major behind the app.

### Correct date markup in demos and readme.

- only some demos show the live timestamp
- demos use the `o-teaser__timestamp-date` class correctly
- the readme uses the `o-teaser__timestamp-date` class correctly,
and also mentions the use of `o-date`

### Screenshots

ordered, before/after

![Screenshot 2020-09-14 at 14 25 16](https://user-images.githubusercontent.com/10405691/93091584-36044c00-f696-11ea-800d-ed8129ac5179.png)
![Screenshot 2020-09-14 at 14 25 22](https://user-images.githubusercontent.com/10405691/93091589-38ff3c80-f696-11ea-99b9-4219e1026639.png)
![Screenshot 2020-09-14 at 14 25 25](https://user-images.githubusercontent.com/10405691/93091596-3997d300-f696-11ea-9c3c-0712d09b195e.png)
![Screenshot 2020-09-14 at 14 25 26](https://user-images.githubusercontent.com/10405691/93091599-3a306980-f696-11ea-8867-cd979cab919d.png)
![Screenshot 2020-09-14 at 14 25 33](https://user-images.githubusercontent.com/10405691/93091600-3ac90000-f696-11ea-8622-8d8942f62745.png)
![Screenshot 2020-09-14 at 14 25 35](https://user-images.githubusercontent.com/10405691/93091601-3ac90000-f696-11ea-8bb9-5f9b4fe176a9.png)
![Screenshot 2020-09-14 at 14 25 39](https://user-images.githubusercontent.com/10405691/93091602-3b619680-f696-11ea-95a0-0a2e9680b1bc.png)
![Screenshot 2020-09-14 at 14 25 42](https://user-images.githubusercontent.com/10405691/93091603-3b619680-f696-11ea-9361-cc6deffd83a7.png)
