### PR TITLE
Remove the opinion background on desktop hero image featured teasers

### DIFF
--- a/demos/src/demo-hero-image.mustache
+++ b/demos/src/demo-hero-image.mustache
@@ -1,0 +1,37 @@
+<div class="demo-container demo-container--full">
+    <div class="o-teaser o-teaser--hero o-teaser--hero-image {{#article-modifier}} o-teaser--{{.}} {{/article-modifier}} o-teaser--has-image" data-o-component="o-teaser">
+        <div class="o-teaser__content">
+            <div class="o-teaser__meta">
+                {{#article-tag-prefix}}<span class="o-teaser__tag-prefix">{{.}}</span>{{/article-tag-prefix}}
+                <a href="#" class="o-teaser__tag">{{article-tag}}</a>
+                {{#article-duration}}
+                    <time class="o-teaser__tag-suffix" datetime="PT3M07S">3:07min</time>
+                {{/article-duration}}
+            </div>
+
+            <h2 class="o-teaser__heading"><a href="#">{{article-heading}}</a></h2>
+
+            {{#article-standfirst}}
+                <p class="o-teaser__standfirst">
+                    <a href="#">
+                        {{article-standfirst}}
+                    </a>
+                </p>
+            {{/article-standfirst}}
+
+            {{#article-timestamp}}
+                <time data-o-component="o-date" class="o-teaser__timestamp" datetime="{{article-timestamp}}">{{article-timestamp}}</time>
+            {{/article-timestamp}}
+        </div>
+
+        {{#article-image-url}}
+            <div class="o-teaser__image-container">
+                <a href="#">
+                    <div class="o-teaser__image-placeholder image-placeholder">
+                        <img src="{{article-image-url}}" class="o-teaser__image" alt="demo image"/>
+                    </div>
+                </a>
+            </div>
+        {{/article-image-url}}
+    </div>
+</div>

--- a/origami.json
+++ b/origami.json
@@ -418,13 +418,13 @@
 			}
 		},
 		{
-			"title": "Hero Image",
+			"title": "Hero With Featured Image",
 			"name": "hero-image",
-			"description": "Hero image teaser",
-			"template": "demos/src/demo-hero.mustache",
+			"description": "Hero teaser with featured image. On large viewports the teaser title overlays the image. On smaller viewports the typical hero teaser is shown, including themes such as opinion and highlight.",
+			"template": "demos/src/demo-hero-image.mustache",
 			"data": {
 				"article-image-url": "https://www.ft.com/__origami/service/image/v2/images/raw/http%3A%2F%2Fim.ft-static.com%2Fcontent%2Fimages%2Fa60ae24b-b87f-439c-bf1b-6e54946b4cf2.img?width=280&source=o-teaser-demo",
-				"article-modifier": "hero-image",
+				"article-modifier": "opinion",
 				"article-tag": "Brexit",
 				"article-heading": "Japan sells negative yield 10-year bonds"
 			}

--- a/src/scss/themes/_hero.scss
+++ b/src/scss/themes/_hero.scss
@@ -63,16 +63,14 @@
 		background-color: oColorsMix(oColorsByName('white'), $opinion-background, 80);
 	}
 
-	&.o-teaser--hero {
-		.o-teaser__content,
-		.o-teaser__image-container:after {
-			background: $opinion-background;
-		}
+	.o-teaser__content,
+	.o-teaser__image-container:after {
+		background: $opinion-background;
+	}
 
-		.o-teaser__content:after {
-			@include oGridRespondTo(S, L) {
-				background: $opinion-background;
-			}
+	.o-teaser__content:after {
+		@include oGridRespondTo(S, L) {
+			background: $opinion-background;
 		}
 	}
 }


### PR DESCRIPTION
That "hero image" teaser variant was added about 4 years ago. Due to the
`has-image` modifier the naming is a little confusing. This variant behaves
like a hero teaser on smaller viewports but on larger viewports the image
is much larger and the copy of the teaser overlays the image, like a poster.
_Note: I suspect due to poor contrast this variant is not accessible, depending
on the image it is used with. I've created an [issue to review](https://github.com/Financial-Times/o-teaser/issues/193) that._

The "hero image" variant has never worked with an opinion, highlight, or
similar modifier which changes the background colour of the teaser. This
can be seen by adding `o-teaser--opinion` modifier to the initial release
v1.1.0.
https://registry.origami.ft.com/components/o-teaser@1.1.0/#demo-hero-image

![Screenshot 2020-11-13 at 13 08 22](https://user-images.githubusercontent.com/10405691/99245730-02f84900-27fc-11eb-9e5e-e24530e41b27.png)

For a while Customer Product's `n-teaser` (which was replaced by `x-teaser`)
removed the `opinion` theme from `hero-image` teasers to avoid this issue.
Instead it was decided to update `o-teaser` to remove the background
so the text sits over the image, as when the `opinion` (etc) modifiers
aren't applied.
https://financialtimes.slack.com/archives/C042NBBTM/p1536142997000100

~2 years later, this PR does that 🎉

Relates to: #102 (comment)

**Large Viewport: Before/After**
![Screenshot 2020-11-16 at 11 02 30](https://user-images.githubusercontent.com/10405691/99245371-5f0e9d80-27fb-11eb-999d-da76b84b6c13.png)

![Screenshot 2020-11-16 at 11 01 36](https://user-images.githubusercontent.com/10405691/99245341-51f1ae80-27fb-11eb-9be2-e1349d61c37a.png)

**Small Viewport: No Change**
![Screenshot 2020-11-16 at 11 02 54](https://user-images.githubusercontent.com/10405691/99245423-75b4f480-27fb-11eb-96ce-cc4a8ef3cbe3.png)