### PR TITLE
Update the partner content label colour to "matisse".

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,7 @@
     "main.scss"
   ],
   "dependencies": {
-    "o-colors": "^5.0.0",
+    "o-colors": "^5.4.0",
     "o-typography": "^6.3.1",
     "o-grid": "^5.0.0",
     "o-icons": "^6.0.0",

--- a/src/scss/elements/_promoted.scss
+++ b/src/scss/elements/_promoted.scss
@@ -10,7 +10,7 @@
 	.o-teaser__promoted-prefix {
 		@include oTypographySans($scale: 0, $include-font-family: false);
 		text-transform: uppercase;
-		color: oColorsByName('oxford-50');
+		color: oColorsByName('matisse');
 		display: block;
 	}
 


### PR DESCRIPTION
FT Creative:
>The choice of the new colour is intentionally different to the FT
>Brand palette, for the same reason the existing color is not used
>in other contexts on ft.com - it's there to create a clear visual
>distinction between our editorial and that of the partner content.