### PR TITLE
Improve the focus outline contrast on hero/live teasers.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -174,6 +174,14 @@
 		@include _oTeaserLarge;
 		@include _oTeaserHero;
 
+		// Additional o-teaser class selector is used to fight o-normalise
+		// specificity, which is unfortunately high to support a :focus-visible
+		// polyfill
+		&.o-teaser *:focus-visible,
+		&.o-teaser *:focus {
+			outline-color: currentColor;
+		}
+
 		&.o-teaser--has-image {
 			@include _oTeaserImageContainer;
 			@include _oTeaserHeroImageContainer;

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -14,6 +14,7 @@
 		// create white text red background
 		@include _oTeaserInverse;
 		background: oColorsByName('crimson');
+
 		.o-teaser__content * {
 			color: white;
 			&:hover {
@@ -21,15 +22,16 @@
 			}
 		}
 
+		.o-teaser__meta a,
 		.o-teaser__heading a,
 		.o-teaser__standfirst a {
 			&:focus,
 			&:hover,
 			&:visited {
 				color: oColorsMix(white, crimson, 90);
+				outline-color: currentColor;
 			}
 		}
-
 
 		// @deprecated - o-teaser__timestamp--inprogress has been replaced by o-teaser__timestamp--live
 		// https://github.com/Financial-Times/o-teaser/issues/173


### PR DESCRIPTION
Fixes: https://financialtimes.atlassian.net/browse/CON-1094
Fixes: https://financialtimes.atlassian.net/browse/CON-1095

live teaser before/after
![live teaser before, low outline contrast](https://user-images.githubusercontent.com/10405691/129921630-fd3e25c8-fa82-4b90-94e0-7f83c2a35892.png)
![live teaser after, higher outline contrast](https://user-images.githubusercontent.com/10405691/129921640-f2808cd2-b93e-4318-b132-0e621211b051.png)
opinion hero teaser before/after
![opinion hero teaser before, low outline contrast](https://user-images.githubusercontent.com/10405691/129921645-91f4b4bc-0dbe-48aa-9cd0-d73fe06fa8b6.png)
![opinion hero teaser after, higher outline contrast](https://user-images.githubusercontent.com/10405691/129921647-20c8bd63-68d9-4301-b340-78f39c7ba8c6.png)
