### PR TITLE
Backport attempt 2: Improve the focus outline contrast on hero/live teasers.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -174,6 +174,14 @@
 		@include _oTeaserLarge;
 		@include _oTeaserHero;
 
+		// Additional o-teaser class selector is used to fight o-normalise
+		// specificity, which is unfortunately high to support a :focus-visible
+		// polyfill
+		&.o-teaser *:focus-visible,
+		&.o-teaser *:focus {
+			outline-color: currentColor;
+		}
+
 		&.o-teaser--has-image {
 			@include _oTeaserImageContainer;
 			@include _oTeaserHeroImageContainer;

--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -14,6 +14,7 @@
 		// create white text red background
 		@include _oTeaserInverse;
 		background: oColorsByName('crimson');
+
 		.o-teaser__content * {
 			color: white;
 			&:hover {
@@ -21,15 +22,16 @@
 			}
 		}
 
+		.o-teaser__meta a,
 		.o-teaser__heading a,
 		.o-teaser__standfirst a {
 			&:focus,
 			&:hover,
 			&:visited {
 				color: oColorsMix(white, crimson, 90);
+				outline-color: currentColor;
 			}
 		}
-
 
 		// @deprecated - o-teaser__timestamp--inprogress has been replaced by o-teaser__timestamp--live
 		// https://github.com/Financial-Times/o-teaser/issues/173


### PR DESCRIPTION
Little issue with the release of this PR:
https://github.com/Financial-Times/o-teaser/pull/213

The `v5.x.x` base branch was not at the latest v5 tag. My mistake. The `v5.x.x` base branch is now up to date.
Since the code changes are small and already approved I'm going to go ahead and merge.