### PR TITLE
Improve the focus outline contrast on hero/live teasers.

### DIFF
--- a/src/scss/_mixins.scss
+++ b/src/scss/_mixins.scss
@@ -173,6 +173,14 @@
 	.o-teaser--hero {
 		@include _oTeaserLarge;
 		@include _oTeaserHero;
+		
+		// Additional o-teaser class selector is used to fight o-normalise
+		// specificity, which is unfortunately high to support a :focus-visible
+		// polyfill
+		&.o-teaser *:focus-visible,
+		&.o-teaser *:focus {
+			outline-color: currentColor;
+		}
 
 		&.o-teaser--has-image {
 			@include _oTeaserImageContainer;


### PR DESCRIPTION
Backporting https://github.com/Financial-Times/o-teaser/pull/212 to version 4 as www.ft.com are currently on that version and require this accessibility issue to be fixed

This was requested in the origami-support Slack channel -- https://financialtimes.slack.com/archives/C02FU5ARJ/p1630402102007400

Fixes: financialtimes.atlassian.net/browse/CON-1094
Fixes: financialtimes.atlassian.net/browse/CON-1095