### PR TITLE
 Improve the focus outline contrast on live teasers. 

### DIFF
--- a/src/scss/themes/_live.scss
+++ b/src/scss/themes/_live.scss
@@ -21,12 +21,14 @@
             }
         }
 
+        .o-teaser__meta a,
         .o-teaser__heading a,
         .o-teaser__standfirst a {
             &:focus,
             &:hover,
             &:visited {
                 color: oColorsMix(white, crimson, 90);
+                outline-color: currentColor;
             }
         }
 


### PR DESCRIPTION
This was missed in the previous backport for v4 -- https://github.com/Financial-Times/o-teaser/pull/215